### PR TITLE
March Release #3 - Interactive components support (Input, Button, Slider)

### DIFF
--- a/docs/css-blend-mode.md
+++ b/docs/css-blend-mode.md
@@ -1,0 +1,16 @@
+# CSS - Blend mode
+
+## Supported types
+
+```
+normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity
+```
+
+## Warning Lack of browser support on SVG element.
+
+Applying `mix-blend-mode` to SVG element is limited in some browsers (safari & mobile browsers) See - https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode#browser_compatibility
+
+### References
+
+- [`mix-blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode)
+- [`background-blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-blend-mode)

--- a/docs/css-multiple-background.md
+++ b/docs/css-multiple-background.md
@@ -1,0 +1,60 @@
+---
+title: "CSS How to handle multiple background fills"
+version: 0.1.0
+revision: 1
+---
+
+# How to handle multiple background fills
+
+## Definition of `"multiple background fills"`
+
+- one or none active solid fill
+- one or more gradient fill above solid fill
+- one or more image fill
+
+## Possible combinations
+
+single solid fill
+
+```css
+._1 {
+  background: #fff;
+}
+._2 {
+  background-color: #fff;
+}
+```
+
+single solid fill with single gradient fill
+
+```css
+._1 {
+  background-color: #fff;
+  background-image: linear-gradient(to bottom, #fff, #fff);
+}
+
+._2 {
+  background: #fff;
+  background-image: linear-gradient(to bottom, #fff, #fff);
+}
+```
+
+no solid fill with single gradient fill
+
+```css
+._1 {
+  background: linear-gradient(to bottom, #fff, #fff);
+}
+
+._2 {
+  background-image: linear-gradient(to bottom, #fff, #fff);
+}
+```
+
+no solid fill with multiple gradient fill
+
+```css
+._1 {
+  background: linear-gradient(to bottom, #fff, #fff), linear-gradient(to bottom, #fff, #fff);
+}
+```

--- a/docs/css-text-gradient.md
+++ b/docs/css-text-gradient.md
@@ -1,0 +1,26 @@
+---
+title: "CSS Gradient on text layer"
+version: 0.1.0
+revision: 1
+---
+
+# CSS - Gradient on Text Layer
+
+Applying a gradient to a text fill is quite different from simply giving a color to a text.
+Yet hooray CSS, it is much more simple than other platforms (flutter, android, ...)
+
+**How to**
+
+```css
+h1 {
+  font-size: 72px;
+  background: -webkit-linear-gradient(#eee, #333);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+```
+
+### References
+
+- https://cssgradient.io/blog/css-gradient-text/
+- https://github.com/gridaco/designto-code/issues/84

--- a/docs/css-text-vertical-align.md
+++ b/docs/css-text-vertical-align.md
@@ -1,0 +1,11 @@
+---
+title: "CSS Vertically align text content"
+version: 0.1.0
+revision: 1
+---
+
+# Vertical align of text content
+
+### References
+
+- https://stackoverflow.com/questions/8865458/how-do-i-vertically-center-text-with-css

--- a/docs/figma-rotation.md
+++ b/docs/figma-rotation.md
@@ -12,6 +12,37 @@ revision: 1
 
 > Figma rotation from [figma plugin docs](https://www.figma.com/plugin-docs/api/properties/nodes-rotation/#docsNav)
 
+## [Note] The rotation value needs to be inverted on the client side.
+
+to rotate something to the clockwise direction,
+
+- figma: -n
+- client: +n (css)
+
+the transform origin
+
+- figma: not specified (always top left)
+- client: top left
+
+**so the conversion from figma to css will be like below**
+
+```
+# figma
+{
+  x: 100,
+  y: 100,
+  rotation: 10,
+}
+
+# css
+.rotate-n {
+  top: 100;
+  left: 100;
+  transform: rotate(-10deg);
+  transform-origin: top left;
+}
+```
+
 ## Transform?
 
 While figma and other major design tools has both transform value, and explicit rotation value (which can be calculated from transform value), The intuitive way to represent a rotation value is by using a `Rotation` token. Overall all figma node properties, the only two property that has impact to final transform (based on css) is `scale` and `rotation`.

--- a/editor-packages/editor-canvas/canvas/canvas.tsx
+++ b/editor-packages/editor-canvas/canvas/canvas.tsx
@@ -320,6 +320,7 @@ export function Canvas({
                 ).map((h) => ({
                   id: h.id,
                   xywh: [h.absoluteX, h.absoluteY, h.width, h.height],
+                  rotation: h.rotation,
                 }))
               : []
           }

--- a/editor-packages/editor-canvas/canvas/hud-surface.tsx
+++ b/editor-packages/editor-canvas/canvas/hud-surface.tsx
@@ -22,6 +22,7 @@ export interface DisplayNodeMeta {
   absoluteY: number;
   width: number;
   height: number;
+  rotation: number;
 }
 
 export function HudSurface({
@@ -41,7 +42,7 @@ export function HudSurface({
 }: {
   offset: XY;
   zoom: number;
-  highlights: { id: string; xywh: XYWH }[];
+  highlights: { id: string; xywh: XYWH; rotation: number }[];
   labelDisplayNodes: DisplayNodeMeta[];
   selectedNodes: DisplayNodeMeta[];
   hide: boolean;
@@ -102,6 +103,7 @@ export function HudSurface({
                   key={h.id}
                   type="xywhr"
                   xywh={h.xywh}
+                  rotation={h.rotation}
                   zoom={zoom}
                   width={2}
                 />
@@ -121,6 +123,7 @@ export function HudSurface({
                     key={s.id}
                     type="xywhr"
                     xywh={xywh}
+                    rotation={s.rotation}
                     zoom={zoom}
                     width={1}
                   />

--- a/editor-packages/editor-canvas/overlay/hover-outline-hightlight.tsx
+++ b/editor-packages/editor-canvas/overlay/hover-outline-hightlight.tsx
@@ -2,46 +2,27 @@ import React from "react";
 import { color_layer_highlight } from "../theme";
 import { get_boinding_box } from "./math";
 import { OulineSide } from "./outline-side";
+import { OverlayContainer } from "./overlay-container";
 import type { OutlineProps } from "./types";
 
 export function HoverOutlineHighlight({ width = 1, ...props }: OutlineProps) {
-  const { xywh, zoom } = props;
+  const { xywh, zoom, rotation } = props;
   const bbox = get_boinding_box({ xywh, scale: zoom });
   const wh: [number, number] = [xywh[2], xywh[3]];
+  const vprops = {
+    wh: wh,
+    zoom: props.zoom,
+    width: width,
+    box: bbox,
+    color: color_layer_highlight,
+  };
+
   return (
-    <>
-      <OulineSide
-        orientation="l"
-        wh={wh}
-        zoom={props.zoom}
-        width={width}
-        box={bbox}
-        color={color_layer_highlight}
-      />
-      <OulineSide
-        orientation="t"
-        wh={wh}
-        zoom={props.zoom}
-        width={width}
-        box={bbox}
-        color={color_layer_highlight}
-      />
-      <OulineSide
-        orientation="b"
-        wh={wh}
-        zoom={props.zoom}
-        width={width}
-        box={bbox}
-        color={color_layer_highlight}
-      />
-      <OulineSide
-        orientation="r"
-        wh={wh}
-        zoom={props.zoom}
-        width={width}
-        box={bbox}
-        color={color_layer_highlight}
-      />
-    </>
+    <OverlayContainer xywh={bbox} rotation={rotation}>
+      <OulineSide orientation="l" {...vprops} />
+      <OulineSide orientation="t" {...vprops} />
+      <OulineSide orientation="b" {...vprops} />
+      <OulineSide orientation="r" {...vprops} />
+    </OverlayContainer>
   );
 }

--- a/editor-packages/editor-canvas/overlay/math.ts
+++ b/editor-packages/editor-canvas/overlay/math.ts
@@ -6,6 +6,8 @@ export function get_boinding_box({
   scale: number;
 }): [number, number, number, number] {
   const [x, y, w, h] = xywh;
+
+  // return the bounding box in [number, number, number, number] form with givven x, y, w, h, rotation and scale.
   const [x1, y1, x2, y2] = [
     x * scale,
     y * scale,

--- a/editor-packages/editor-canvas/overlay/overlay-container.tsx
+++ b/editor-packages/editor-canvas/overlay/overlay-container.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+/**
+ * @default - TODO: rotation not supported
+ * @returns
+ */
+export function OverlayContainer({
+  xywh,
+  rotation = 0,
+  children,
+}: {
+  xywh: [number, number, number, number];
+  rotation: number;
+  children: React.ReactNode;
+}) {
+  // const [x, y, w, h] = xywh;
+  return (
+    <div
+      id="overlay-container"
+      style={{
+        pointerEvents: "none",
+        willChange: "transform, opacity",
+        // transformOrigin: `${x}px ${y}px`,
+        // transform: `rotate(${-rotation}deg)`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/editor-packages/editor-canvas/overlay/readonly-select-hightlight.tsx
+++ b/editor-packages/editor-canvas/overlay/readonly-select-hightlight.tsx
@@ -3,12 +3,13 @@ import type { OutlineProps } from "./types";
 import { color_layer_readonly_highlight } from "../theme";
 import { get_boinding_box } from "./math";
 import { OulineSide } from "./outline-side";
+import { OverlayContainer } from "./overlay-container";
 
 export function ReadonlySelectHightlight({
   width = 1,
   ...props
 }: OutlineProps) {
-  const { xywh, zoom } = props;
+  const { xywh, zoom, rotation } = props;
   const bbox = get_boinding_box({ xywh, scale: zoom });
   const wh: [number, number] = [xywh[2], xywh[3]];
 
@@ -16,12 +17,16 @@ export function ReadonlySelectHightlight({
   const handle_size = 3;
   const dot_size = 4;
 
+  const sideprops = {
+    wh: wh,
+    zoom: props.zoom,
+    width: width,
+    box: bbox,
+    color: color_layer_readonly_highlight,
+  };
+
   return (
-    <div
-      style={{
-        pointerEvents: "none",
-      }}
-    >
+    <OverlayContainer xywh={bbox} rotation={rotation}>
       <>
         <ReadonlyHandle
           box={bbox}
@@ -83,40 +88,12 @@ export function ReadonlySelectHightlight({
         />
       </>
       <>
-        <OulineSide
-          orientation="l"
-          wh={wh}
-          zoom={props.zoom}
-          width={width}
-          box={bbox}
-          color={color_layer_readonly_highlight}
-        />
-        <OulineSide
-          orientation="t"
-          wh={wh}
-          zoom={props.zoom}
-          width={width}
-          box={bbox}
-          color={color_layer_readonly_highlight}
-        />
-        <OulineSide
-          orientation="b"
-          wh={wh}
-          zoom={props.zoom}
-          width={width}
-          box={bbox}
-          color={color_layer_readonly_highlight}
-        />
-        <OulineSide
-          orientation="r"
-          wh={wh}
-          zoom={props.zoom}
-          width={width}
-          box={bbox}
-          color={color_layer_readonly_highlight}
-        />
+        <OulineSide orientation="l" {...sideprops} />
+        <OulineSide orientation="t" {...sideprops} />
+        <OulineSide orientation="b" {...sideprops} />
+        <OulineSide orientation="r" {...sideprops} />
       </>
-    </div>
+    </OverlayContainer>
   );
 }
 

--- a/editor/components/editor/editor-browser-meta-head/index.tsx
+++ b/editor/components/editor/editor-browser-meta-head/index.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Head from "next/head";
+import { useEditorState } from "core/states";
+
+export function EditorBrowserMetaHead({
+  children,
+}: {
+  children: React.ReactChild;
+}) {
+  const [state] = useEditorState();
+
+  return (
+    <>
+      <Head>
+        <title>
+          {state?.design?.name ? `Grida | ${state?.design?.name}` : "Loading.."}
+        </title>
+      </Head>
+      {children}
+    </>
+  );
+}

--- a/editor/components/editor/index.ts
+++ b/editor/components/editor/index.ts
@@ -1,3 +1,4 @@
 export * from "./editor-appbar";
+export * from "./editor-browser-meta-head";
 export * from "./editor-layer-hierarchy";
 export * from "./editor-sidebar";

--- a/editor/core/reducers/editor-reducer.ts
+++ b/editor/core/reducers/editor-reducer.ts
@@ -27,7 +27,12 @@ export function editorReducer(state: EditorState, action: Action): EditorState {
 
         const new_selections = [node].filter(Boolean);
         _canvas_state_store.saveLastSelection(...new_selections);
+
+        // assign new nodes set to the state.
         draft.selectedNodes = new_selections;
+
+        // remove the initial selection after the first interaction.
+        draft.selectedNodesInitial = null;
       });
     }
     case "select-page": {

--- a/editor/core/reducers/editor-reducer.ts
+++ b/editor/core/reducers/editor-reducer.ts
@@ -16,8 +16,14 @@ export function editorReducer(state: EditorState, action: Action): EditorState {
       console.info("cleard console by editorReducer#select-node");
 
       // update router
-      router.query.node = node ?? state.selectedPage;
-      router.push(router);
+      router.push(
+        {
+          pathname: router.pathname,
+          query: { ...router.query, node: node ?? state.selectedPage },
+        },
+        undefined,
+        {}
+      );
 
       return produce(state, (draft) => {
         const _canvas_state_store = new CanvasStateStore(
@@ -42,8 +48,14 @@ export function editorReducer(state: EditorState, action: Action): EditorState {
       console.info("cleard console by editorReducer#select-page");
 
       // update router
-      router.query.node = page;
-      router.push(router);
+      router.push(
+        {
+          pathname: router.pathname,
+          query: { ...router.query, node: page },
+        },
+        undefined,
+        {}
+      );
 
       return produce(state, (draft) => {
         const _canvas_state_store = new CanvasStateStore(filekey, page);

--- a/editor/core/states/editor-initial-state.ts
+++ b/editor/core/states/editor-initial-state.ts
@@ -4,6 +4,7 @@ export function createInitialEditorState(editor: EditorSnapshot): EditorState {
   return {
     selectedPage: editor.selectedPage,
     selectedNodes: editor.selectedNodes,
+    selectedNodesInitial: editor.selectedNodes,
     selectedLayersOnPreview: editor.selectedLayersOnPreview,
     design: editor.design,
   };
@@ -13,6 +14,7 @@ export function createPendingEditorState(): EditorState {
   return {
     selectedPage: null,
     selectedNodes: [],
+    selectedNodesInitial: null,
     selectedLayersOnPreview: [],
     design: null,
   };

--- a/editor/core/states/editor-state.ts
+++ b/editor/core/states/editor-state.ts
@@ -6,6 +6,12 @@ export interface EditorState {
   selectedPage: string;
   selectedNodes: string[];
   selectedLayersOnPreview: string[];
+  /**
+   * this is the initial node selection triggered by the url param, not caused by the user interaction.
+   * after once user interacts and selects other node, this selection will be cleared, set to null.
+   * > only set by the url pararm or other programatic cause, not caused by after-load user interaction.
+   */
+  selectedNodesInitial?: string[] | null;
   design: FigmaReflectRepository;
 }
 
@@ -13,6 +19,7 @@ export interface EditorSnapshot {
   selectedPage: string;
   selectedNodes: string[];
   selectedLayersOnPreview: string[];
+  selectedNodesInitial?: string[] | null;
   design: FigmaReflectRepository;
 }
 

--- a/editor/core/states/editor-state.ts
+++ b/editor/core/states/editor-state.ts
@@ -25,6 +25,11 @@ export interface EditorSnapshot {
 
 export interface FigmaReflectRepository {
   /**
+   * name of the file
+   */
+  name: string;
+
+  /**
    * fileid; filekey
    */
   key: string;

--- a/editor/hooks/index.ts
+++ b/editor/hooks/index.ts
@@ -3,3 +3,4 @@ export * from "./use-async-effect";
 export * from "./use-auth-state";
 export * from "./use-figma-access-token";
 export * from "./use-target-node";
+export * from "./use-window-size";

--- a/editor/hooks/index.ts
+++ b/editor/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./use-design";
 export * from "./use-async-effect";
 export * from "./use-auth-state";
 export * from "./use-figma-access-token";
+export * from "./use-target-node";

--- a/editor/hooks/use-target-node.ts
+++ b/editor/hooks/use-target-node.ts
@@ -7,7 +7,10 @@ import { utils as _design_utils } from "@design-sdk/core";
 const designq = _design_utils.query;
 
 export function useTargetContainer() {
-  const [t, setT] = useState<{ target: ReflectSceneNode; root: DesignInput }>();
+  const [t, setT] = useState<{ target: ReflectSceneNode; root: DesignInput }>({
+    target: undefined,
+    root: undefined,
+  });
   const [state] = useEditorState();
 
   //

--- a/editor/hooks/use-target-node.ts
+++ b/editor/hooks/use-target-node.ts
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import type { ReflectSceneNode } from "@design-sdk/core";
+import { useEditorState } from "core/states";
+import { DesignInput } from "@designto/config/input";
+
+import { utils as _design_utils } from "@design-sdk/core";
+const designq = _design_utils.query;
+
+export function useTargetContainer() {
+  const [t, setT] = useState<{ target: ReflectSceneNode; root: DesignInput }>();
+  const [state] = useEditorState();
+
+  //
+  useEffect(() => {
+    const thisPageNodes = state.selectedPage
+      ? state.design.pages.find((p) => p.id == state.selectedPage).children
+      : null;
+
+    const targetId =
+      state?.selectedNodes?.length === 1 ? state.selectedNodes[0] : null;
+
+    const container_of_target =
+      designq.find_node_by_id_under_inpage_nodes(targetId, thisPageNodes) ||
+      null;
+
+    const root = thisPageNodes
+      ? container_of_target &&
+        (container_of_target.origin === "COMPONENT"
+          ? DesignInput.forMasterComponent({
+              master: container_of_target,
+              all: state.design.pages,
+              components: state.design.components,
+            })
+          : DesignInput.fromDesignWithComponents({
+              design: container_of_target,
+              components: state.design.components,
+            }))
+      : state.design?.input;
+
+    const target =
+      designq.find_node_by_id_under_entry(targetId, root?.entry) ?? root?.entry;
+
+    setT({ target, root });
+  }, [state?.selectedNodes, state?.selectedPage, state?.design?.pages]);
+
+  return t;
+}

--- a/editor/hooks/use-window-size.ts
+++ b/editor/hooks/use-window-size.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+/**
+ * from https://usehooks.com/useWindowSize/
+ * @returns
+ */
+export function useWindowSize(): {
+  width?: number;
+  height?: number;
+} {
+  // Initialize state with undefined width/height so server and client renders match
+  // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
+  const [windowSize, setWindowSize] = useState({
+    width: undefined,
+    height: undefined,
+  });
+  useEffect(() => {
+    // Handler to call on window resize
+    function handleResize() {
+      // Set window width/height to state
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+    // Add event listener
+    window.addEventListener("resize", handleResize);
+    // Call handler right away so state gets updated with initial window size
+    handleResize();
+    // Remove event listener on cleanup
+    return () => window.removeEventListener("resize", handleResize);
+  }, []); // Empty array ensures that effect is only run on mount
+  return windowSize;
+}

--- a/editor/pages/files/[key]/index.tsx
+++ b/editor/pages/files/[key]/index.tsx
@@ -8,6 +8,7 @@ import { useDesignFile } from "hooks";
 
 import { warmup } from "scaffolds/editor";
 import { FileResponse } from "@design-sdk/figma-remote-types";
+import { EditorBrowserMetaHead } from "components/editor";
 
 export default function FileEntryEditor() {
   const router = useRouter();
@@ -64,6 +65,7 @@ export default function FileEntryEditor() {
         selectedPage: warmup.selectedPage(prevstate, pages, nodeid && [nodeid]),
         selectedLayersOnPreview: [],
         design: {
+          name: file.name,
           input: null,
           components: components,
           // styles: null,
@@ -131,7 +133,9 @@ export default function FileEntryEditor() {
     <SigninToContinueBannerPrmoptProvider>
       <StateProvider state={safe_value} dispatch={handleDispatch}>
         <EditorDefaultProviders>
-          <Editor loading={loading} />
+          <EditorBrowserMetaHead>
+            <Editor loading={loading} />
+          </EditorBrowserMetaHead>
         </EditorDefaultProviders>
       </StateProvider>
     </SigninToContinueBannerPrmoptProvider>

--- a/editor/pages/files/[key]/index.tsx
+++ b/editor/pages/files/[key]/index.tsx
@@ -54,10 +54,13 @@ export default function FileEntryEditor() {
         ),
       };
     } else {
+      const initialSelections =
+        // set selected nodes initially only if the nodeid is the id of non-page node
+        pages.some((p) => p.id === nodeid) ? [] : nodeid ? [nodeid] : [];
+
       val = {
-        selectedNodes:
-          // set selected nodes initially only if the nodeid is the id of non-page node
-          pages.some((p) => p.id === nodeid) ? [] : nodeid ? [nodeid] : [],
+        selectedNodes: initialSelections,
+        selectedNodesInitial: initialSelections,
         selectedPage: warmup.selectedPage(prevstate, pages, nodeid && [nodeid]),
         selectedLayersOnPreview: [],
         design: {

--- a/editor/pages/files/[key]/index.tsx
+++ b/editor/pages/files/[key]/index.tsx
@@ -55,7 +55,10 @@ export default function FileEntryEditor() {
       };
     } else {
       val = {
-        selectedNodes: [],
+        selectedNodes:
+          // set selected nodes initially only if the nodeid is the id of non-page node
+          pages.some((p) => p.id === nodeid) ? [] : nodeid ? [nodeid] : [],
+        selectedPage: warmup.selectedPage(prevstate, pages, nodeid && [nodeid]),
         selectedLayersOnPreview: [],
         design: {
           input: null,
@@ -64,7 +67,6 @@ export default function FileEntryEditor() {
           key: filekey,
           pages: pages,
         },
-        selectedPage: warmup.selectedPage(prevstate, pages, null),
       };
     }
 

--- a/editor/pages/files/index.tsx
+++ b/editor/pages/files/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import Head from "next/head";
 import { DefaultEditorWorkspaceLayout } from "layouts/default-editor-workspace-layout";
 import {
   Cards,
@@ -19,6 +20,9 @@ export default function FilesPage() {
 
   return (
     <>
+      <Head>
+        <title>Grida | files</title>
+      </Head>
       <DefaultEditorWorkspaceLayout
         backgroundColor={colors.color_editor_bg_on_dark}
         leftbar={<HomeSidebar />}

--- a/editor/pages/index.tsx
+++ b/editor/pages/index.tsx
@@ -1,13 +1,22 @@
+import React from "react";
+import Head from "next/head";
+
 import { HomeInput } from "scaffolds/home-input";
 import { HomeDashboard } from "scaffolds/home-dashboard";
-import React from "react";
 import { useAuthState } from "hooks/use-auth-state";
 
 export default function Home() {
   const authstate = useAuthState();
 
   // region - dev injected
-  return <HomeDashboard />;
+  return (
+    <>
+      <Head>
+        <title>Grida | Home</title>
+      </Head>
+      <HomeDashboard />
+    </>
+  );
   // endregion
 
   switch (authstate) {

--- a/editor/scaffolds/canvas/canvas.tsx
+++ b/editor/scaffolds/canvas/canvas.tsx
@@ -14,6 +14,19 @@ import { IsolateModeCanvas } from "./isolate-mode";
  */
 export function VisualContentArea() {
   const [state] = useEditorState();
+
+  // this hook is used for focusing the node on the first load with the initial selection is provided externally.
+  useEffect(() => {
+    // if the initial selection is available, and not empty
+    if (state.selectedNodesInitial?.length) {
+      // trigger isolation mode once.
+      setMode("isolate");
+
+      // TODO: set explicit canvas initial transform.
+      // make the canvas fit to the initial target even when the isolation mode is complete by the user.
+    }
+  }, [state.selectedNodesInitial]);
+
   const [canvasSizingRef, canvasBounds] = useMeasure();
 
   const { highlightedLayer, highlightLayer } = useWorkspace();
@@ -74,6 +87,7 @@ export function VisualContentArea() {
                 dispatch({ type: "select-node", node: null });
               }}
               nodes={thisPageNodes}
+              // initialTransform={ } // TODO: if the initial selection is provided from first load, from the query param, we have to focus to fit that node.
               renderItem={(p) => {
                 return <Preview key={p.node.id} target={p.node} {...p} />;
               }}

--- a/editor/scaffolds/canvas/canvas.tsx
+++ b/editor/scaffolds/canvas/canvas.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import styled from "@emotion/styled";
-import { EditorAppbarFragments } from "components/editor";
 import { Canvas } from "@code-editor/canvas";
 import { useEditorState, useWorkspace } from "core/states";
 import { Preview } from "scaffolds/preview";
@@ -8,17 +7,22 @@ import useMeasure from "react-use-measure";
 import { useDispatch } from "core/dispatch";
 import { FrameTitleRenderer } from "./render/frame-title";
 import { IsolateModeCanvas } from "./isolate-mode";
+import { useRouter } from "next/router";
+
+type ViewMode = "full" | "isolate";
 
 /**
  * Statefull canvas segment that contains canvas as a child, with state-data connected.
  */
 export function VisualContentArea() {
   const [state] = useEditorState();
+  const router = useRouter();
+  const { mode: q_mode } = router.query;
 
   // this hook is used for focusing the node on the first load with the initial selection is provided externally.
   useEffect(() => {
-    // if the initial selection is available, and not empty
-    if (state.selectedNodesInitial?.length) {
+    // if the initial selection is available, and not empty &&
+    if (state.selectedNodesInitial?.length && q_mode == "isolate") {
       // trigger isolation mode once.
       setMode("isolate");
 
@@ -42,7 +46,14 @@ export function VisualContentArea() {
 
   const isEmptyPage = thisPageNodes?.length === 0;
 
-  const [mode, setMode] = useState<"full" | "isolate">("full");
+  const [mode, _setMode] = useState<ViewMode>("full");
+
+  const setMode = (m: ViewMode) => {
+    _setMode(m);
+
+    // update the router
+    (router.query.mode = m) && router.push(router);
+  };
 
   return (
     <CanvasContainer

--- a/editor/scaffolds/canvas/isolate-mode.tsx
+++ b/editor/scaffolds/canvas/isolate-mode.tsx
@@ -7,41 +7,13 @@ import { VanillaRunner } from "components/app-runner/vanilla-app-runner";
 import { IsolatedCanvas } from "components/canvas";
 import { PreviewAndRunPanel } from "components/preview-and-run";
 import { useEditorState } from "core/states";
-import { DesignInput } from "@designto/config/input";
-
-import { utils as _design_utils } from "@design-sdk/core";
-const designq = _design_utils.query;
+import { useTargetContainer } from "hooks";
 
 export function IsolateModeCanvas({ onClose }: { onClose: () => void }) {
   const [state] = useEditorState();
   const [preview, setPreview] = useState<Result>();
 
-  const thisPageNodes = state.selectedPage
-    ? state.design.pages.find((p) => p.id == state.selectedPage).children
-    : null;
-
-  const targetId =
-    state?.selectedNodes?.length === 1 ? state.selectedNodes[0] : null;
-
-  const container_of_target =
-    designq.find_node_by_id_under_inpage_nodes(targetId, thisPageNodes) || null;
-
-  const root = thisPageNodes
-    ? container_of_target &&
-      (container_of_target.origin === "COMPONENT"
-        ? DesignInput.forMasterComponent({
-            master: container_of_target,
-            all: state.design.pages,
-            components: state.design.components,
-          })
-        : DesignInput.fromDesignWithComponents({
-            design: container_of_target,
-            components: state.design.components,
-          }))
-    : state.design?.input;
-
-  const target =
-    designq.find_node_by_id_under_entry(targetId, root?.entry) ?? root?.entry;
+  const { target, root } = useTargetContainer();
 
   const on_preview_result = (result: Result) => {
     //@ts-ignore
@@ -98,7 +70,7 @@ export function IsolateModeCanvas({ onClose }: { onClose: () => void }) {
 
   return (
     <IsolatedCanvas
-      key={targetId}
+      key={target?.id}
       onExit={onClose}
       defaultSize={{
         width: target?.width ?? 375,

--- a/editor/scaffolds/code/index.tsx
+++ b/editor/scaffolds/code/index.tsx
@@ -11,15 +11,12 @@ import {
   ImageRepository,
   MainImageRepository,
 } from "@design-sdk/core/assets-repository";
-import { DesignInput } from "@designto/config/input";
 import { useEditorState, useWorkspaceState } from "core/states";
 import { utils_dart } from "utils";
 import type { ReflectSceneNode } from "@design-sdk/core";
-
-import { utils as _design_utils } from "@design-sdk/core";
-import assert from "assert";
 import { RemoteImageRepositories } from "@design-sdk/figma-remote/lib/asset-repository/image-repository";
-const designq = _design_utils.query;
+import { useTargetContainer } from "hooks/use-target-node";
+import assert from "assert";
 
 export function CodeSegment() {
   const router = useRouter();
@@ -30,35 +27,10 @@ export function CodeSegment() {
     wstate.preferences.framework_config
   );
 
+  const { target: targetted, root } = useTargetContainer();
+
   const enable_components =
     wstate.preferences.enable_preview_feature_components_support;
-
-  const thisPageNodes = state.selectedPage
-    ? state.design.pages.find((p) => p.id == state.selectedPage).children
-    : null;
-
-  const targetId =
-    state?.selectedNodes?.length === 1 ? state.selectedNodes[0] : null;
-
-  const container_of_target =
-    designq.find_node_by_id_under_inpage_nodes(targetId, thisPageNodes) || null;
-
-  const root = thisPageNodes
-    ? container_of_target &&
-      (container_of_target.origin === "COMPONENT"
-        ? DesignInput.forMasterComponent({
-            master: container_of_target,
-            all: state.design.pages,
-            components: state.design.components,
-          })
-        : DesignInput.fromDesignWithComponents({
-            design: container_of_target,
-            components: state.design.components,
-          }))
-    : state.design?.input;
-
-  const targetted =
-    designq.find_node_by_id_under_entry(targetId, root?.entry) ?? root?.entry;
 
   const targetStateRef =
     useRef<{

--- a/editor/scaffolds/code/index.tsx
+++ b/editor/scaffolds/code/index.tsx
@@ -7,7 +7,10 @@ import { get_framework_config } from "query/to-code-options-from-query";
 import { CodeOptionsControl } from "components/codeui-code-options-control";
 import { designToCode, Result } from "@designto/code";
 import { config } from "@designto/config";
-import { MainImageRepository } from "@design-sdk/core/assets-repository";
+import {
+  ImageRepository,
+  MainImageRepository,
+} from "@design-sdk/core/assets-repository";
 import { DesignInput } from "@designto/config/input";
 import { useEditorState, useWorkspaceState } from "core/states";
 import { utils_dart } from "utils";
@@ -15,6 +18,7 @@ import type { ReflectSceneNode } from "@design-sdk/core";
 
 import { utils as _design_utils } from "@design-sdk/core";
 import assert from "assert";
+import { RemoteImageRepositories } from "@design-sdk/figma-remote/lib/asset-repository/image-repository";
 const designq = _design_utils.query;
 
 export function CodeSegment() {
@@ -85,6 +89,24 @@ export function CodeSegment() {
     const __target = targetted;
     const __framework_config = framework_config;
     if (__target && __framework_config) {
+      if (!MainImageRepository.isReady) {
+        // this is not the smartest way, but the image repo has a design flaw.
+        // this happens when the target node is setted on the query param on first load, when the image repo is not set by the higher editor container.
+        MainImageRepository.instance = new RemoteImageRepositories(
+          state.design.key,
+          {
+            // setting this won't load any image btw. (just to prevent errors)
+            authentication: { accessToken: "" },
+          }
+        );
+        MainImageRepository.instance.register(
+          new ImageRepository(
+            "fill-later-assets",
+            "grida://assets-reservation/images/"
+          )
+        );
+      }
+
       const _input = {
         id: __target.id,
         name: __target.name,

--- a/editor/scaffolds/editor/warmup.ts
+++ b/editor/scaffolds/editor/warmup.ts
@@ -7,13 +7,11 @@ import {
 import { createInitialWorkspaceState } from "core/states";
 import { workspaceReducer } from "core/reducers";
 import { PendingState } from "core/utility-types";
-import { DesignInput } from "@designto/config/input";
-import { TargetNodeConfig } from "query/target-node";
 import { WorkspaceAction } from "core/actions";
 import { FileResponse } from "@design-sdk/figma-remote-types";
 import { convert } from "@design-sdk/figma-node-conversion";
 import { mapper } from "@design-sdk/figma-remote";
-import { find, visit } from "tree-visit";
+import { visit } from "tree-visit";
 
 const pending_workspace_state = createPendingWorkspaceState();
 //
@@ -96,24 +94,6 @@ export function componentsFrom(
     })
     .filter((c) => c)
     .reduce(tomap, {});
-}
-
-export function initializeDesign(design: TargetNodeConfig): EditorSnapshot {
-  return {
-    selectedNodes: [design.node],
-    selectedLayersOnPreview: [],
-    selectedPage: null,
-    design: {
-      pages: [],
-      components: null,
-      // styles: null,
-      key: design.file,
-      input: DesignInput.fromApiResponse({
-        ...design,
-        entry: design.reflect,
-      }),
-    },
-  };
 }
 
 export function safestate(initialState) {

--- a/editor/scaffolds/preview/index.tsx
+++ b/editor/scaffolds/preview/index.tsx
@@ -167,7 +167,7 @@ export function Preview({
         width: target.width,
         height: target.height,
         borderRadius: 1,
-        backgroundColor: bg_color_str,
+        backgroundColor: !preview && bg_color_str, // clear bg after preview is rendered.
         contain: "layout style paint",
       }}
     >

--- a/packages/builder-css-styles/border-radius/index.ts
+++ b/packages/builder-css-styles/border-radius/index.ts
@@ -60,10 +60,11 @@ export function borderRadius(r: BorderRadiusManifest): CSSProperties {
         "border-radius": px(r.all),
       };
     } else {
-      console.warn("elliptical border radius not supported");
+      // example - https://codepen.io/Mahe76/pen/ExZbdro
       return {
-        "border-radius": px(r.all.x),
+        "border-radius": `${px(r.all.x)} / ${px(r.all.y)}`,
       };
+      // TODO: support short handed version - `50%`
     }
   } else {
     return {

--- a/packages/builder-css-styles/border/index.ts
+++ b/packages/builder-css-styles/border/index.ts
@@ -33,5 +33,7 @@ export function border(border: Border): CSSProperties {
 }
 
 export function borderSide(borderSide: BorderSide): CSSProperty.Border {
-  return `solid ${px(borderSide.width)} ${color(borderSide.color)}`;
+  return `${borderSide.style ?? "solid"} ${px(borderSide.width)} ${color(
+    borderSide.color
+  )}`;
 }

--- a/packages/builder-css-styles/color/index.ts
+++ b/packages/builder-css-styles/color/index.ts
@@ -19,8 +19,8 @@ export function color(input: CssColorInputLike | Color): string {
   } else if (input instanceof CssNamedColor) {
     return input.name;
   } else if (typeof input == "object") {
-    // with alpha
-    if ("r" in input && "a" in input) {
+    // with alpha  (if alpha is 1, use rgb format instead)
+    if ("r" in input && "a" in input && input.a !== 1) {
       const a = safe_alpha_fallback(validAlphaValue(input.a));
       const rgba = input as ICssRGBA;
       const _r = validColorValue(rgba.r) ?? 0;
@@ -31,6 +31,11 @@ export function color(input: CssColorInputLike | Color): string {
     // no alpha
     else if ("r" in input && "a"! in input) {
       const rgb = input as RGB;
+      const named = namedcolor(rgb);
+      if (named) {
+        return named;
+      }
+
       return `rgb(${validColorValue(rgb.r) ?? 0}, ${
         validColorValue(rgb.g) ?? 0
       }, ${validColorValue(rgb.b) ?? 0})`;
@@ -41,6 +46,29 @@ export function color(input: CssColorInputLike | Color): string {
     )}" cannot be interpreted as valid css color value`;
   }
 }
+
+/**
+ * rgb value of white, black as named colors
+ * @param rgb
+ */
+const namedcolor = (rgb: RGB) => {
+  // black
+  if (rgb.r === 0 && rgb.g === 0 && rgb.b === 0) {
+    return "black";
+  }
+  // white
+  if (rgb.r === 1 && rgb.g === 1 && rgb.b === 1) {
+    return "white";
+  }
+  // blue
+  if (rgb.r === 0 && rgb.g === 0 && rgb.b === 1) {
+    return "blue";
+  }
+  // red
+  if (rgb.r === 1 && rgb.g === 0 && rgb.b === 0) {
+    return "red";
+  }
+};
 
 const validColorValue = (f: number) => {
   if (f === undefined) {

--- a/packages/builder-css-styles/index.ts
+++ b/packages/builder-css-styles/index.ts
@@ -9,6 +9,7 @@ export * from "./font-weight";
 export * from "./font-family";
 export * from "./text-decoration";
 export * from "./text-shadow";
+export * from "./text-transform";
 export * from "./gradient";
 export * from "./padding";
 export * from "./margin";

--- a/packages/builder-css-styles/linear-gradient/index.ts
+++ b/packages/builder-css-styles/linear-gradient/index.ts
@@ -5,17 +5,23 @@ import { color } from "../color";
 /**
  * https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient()
  *
+ * TODO:
+ * - [ ] stops support (position)
+ *
  * @param g
  * @returns
  */
 export function linearGradient(g: LinearGradientManifest): CSSProperty.Color {
-  // throw "css gradient not ready";
-  // TODO:
-  // 1. stops support
-  // 2. angle support
-  var angleDeg =
+  const angle =
     (Math.atan2(g.begin.y - g.end.y, g.begin.x - g.end.x) * 180) / Math.PI;
 
+  const gradient_angle =
+    angle +
+    // when the rotation value is 0, it means the gradient direction is left to right, which in css, it is 90deg.
+    // so we have to subtract 90.
+    // TODO: consider: extract this outside of the styles module?
+    -90;
+
   const colors = g.colors.map(color).join(", ");
-  return `linear-gradient(${angleDeg}deg, ${colors})`;
+  return `linear-gradient(${gradient_angle}deg, ${colors})`;
 }

--- a/packages/builder-css-styles/text-transform/index.ts
+++ b/packages/builder-css-styles/text-transform/index.ts
@@ -1,0 +1,20 @@
+import { TextTransform } from "@reflect-ui/core";
+
+export function textTransform(tt: TextTransform) {
+  switch (tt) {
+    case TextTransform.capitalize:
+      return "capitalize";
+    case TextTransform.lowercase:
+      return "lowercase";
+    case TextTransform.uppercase:
+      return "uppercase";
+    case TextTransform.fullwidth:
+      return "full-width";
+    case TextTransform.fullsizekana:
+      return "full-size-kana";
+    case TextTransform.none:
+    default:
+      // for none, we don't explicitly set it - to make it shorter.
+      return;
+  }
+}

--- a/packages/builder-css-styles/tricks/trick-flex-sizing/index.ts
+++ b/packages/builder-css-styles/tricks/trick-flex-sizing/index.ts
@@ -30,6 +30,8 @@ export function flexsizing({
     case MainAxisSize.max: {
       return {
         "align-self": "stretch",
+        width: width && length(width),
+        height: height && length(height),
       };
     }
     case MainAxisSize.min: {

--- a/packages/builder-css-styles/tricks/trick-flex-sizing/index.ts
+++ b/packages/builder-css-styles/tricks/trick-flex-sizing/index.ts
@@ -37,7 +37,7 @@ export function flexsizing({
         case Axis.horizontal:
         case Axis.vertical:
           return {
-            flex: "none",
+            flex: flex > 0 ? flex : "none", // 1+
             width: width && length(width),
             height: height && length(height),
           };

--- a/packages/builder-react-native/rn-build-inline-style-widget/rn-inline-style-module-builder.ts
+++ b/packages/builder-react-native/rn-build-inline-style-widget/rn-inline-style-module-builder.ts
@@ -11,7 +11,7 @@ import {
 } from "@web-builder/react-core";
 import {
   buildJsx,
-  getWidgetStylesConfigMap,
+  StylesConfigMapBuilder,
   JSXWithoutStyleElementConfig,
   JSXWithStyleElementConfig,
   WidgetStyleConfigMap,
@@ -48,7 +48,8 @@ export class ReactNativeInlineStyleBuilder {
   private readonly widgetName: string;
   readonly config: reactnative_config.ReactNativeInlineStyleConfig;
   private readonly namer: ScopedVariableNamer;
-  private readonly stylesConfigWidgetMap: WidgetStyleConfigMap;
+  private readonly stylesMapper: StylesConfigMapBuilder;
+  // private readonly stylesConfigWidgetMap: WidgetStyleConfigMap;
 
   constructor({
     entry,
@@ -64,7 +65,8 @@ export class ReactNativeInlineStyleBuilder {
       entry.key.id,
       ReservedKeywordPlatformPresets.react
     );
-    this.stylesConfigWidgetMap = getWidgetStylesConfigMap(entry, {
+
+    this.stylesMapper = new StylesConfigMapBuilder(entry, {
       namer: this.namer,
       rename_tag: false,
     });
@@ -73,7 +75,7 @@ export class ReactNativeInlineStyleBuilder {
   private stylesConfig(
     id: string
   ): JSXWithStyleElementConfig | JSXWithoutStyleElementConfig {
-    return this.stylesConfigWidgetMap.get(id);
+    return this.stylesMapper.map.get(id);
   }
 
   private jsxBuilder(widget: JsxWidget) {

--- a/packages/builder-react-native/rn-build-styled-component-widget/rn-styled-components-module-builder.ts
+++ b/packages/builder-react-native/rn-build-styled-component-widget/rn-styled-components-module-builder.ts
@@ -9,11 +9,7 @@ import {
   styled_components_imports,
 } from "@web-builder/react-core";
 import { JsxWidget } from "@web-builder/core";
-import {
-  buildJsx,
-  getWidgetStylesConfigMap,
-  WidgetStyleConfigMap,
-} from "@web-builder/core/builders";
+import { buildJsx, StylesConfigMapBuilder } from "@web-builder/core/builders";
 import {
   react as react_config,
   reactnative as rn_config,
@@ -28,7 +24,7 @@ import {
 export class ReactNativeStyledComponentsModuleBuilder {
   private readonly entry: JsxWidget;
   private readonly widgetName: string;
-  private readonly styledConfigWidgetMap: WidgetStyleConfigMap;
+  private readonly stylesMapper: StylesConfigMapBuilder;
   private readonly namer: ScopedVariableNamer;
   readonly config: rn_config.ReactNativeStyledComponentsConfig;
 
@@ -45,17 +41,21 @@ export class ReactNativeStyledComponentsModuleBuilder {
       entry.key.id,
       ReservedKeywordPlatformPresets.react
     );
-    this.styledConfigWidgetMap = getWidgetStylesConfigMap(entry, {
+
+    StylesConfigMapBuilder;
+
+    this.stylesMapper = new StylesConfigMapBuilder(entry, {
       namer: this.namer,
       rename_tag: true /** styled component tag shoule be renamed */,
     });
+
     this.config = config;
   }
 
   private styledConfig(
     id: string
   ): StyledComponentJSXElementConfig | NoStyleJSXElementConfig {
-    return this.styledConfigWidgetMap.get(id);
+    return this.stylesMapper.map.get(id);
   }
 
   private jsxBuilder(widget: JsxWidget) {
@@ -101,11 +101,10 @@ export class ReactNativeStyledComponentsModuleBuilder {
   }
 
   partDeclarations() {
-    return Array.from(this.styledConfigWidgetMap.keys())
+    return Array.from(this.stylesMapper.map.keys())
       .map((k) => {
-        return (
-          this.styledConfigWidgetMap.get(k) as StyledComponentJSXElementConfig
-        ).styledComponent;
+        return (this.stylesMapper.map.get(k) as StyledComponentJSXElementConfig)
+          .styledComponent;
       })
       .filter((s) => s);
   }

--- a/packages/builder-web-core/widgets-native/flex/index.ts
+++ b/packages/builder-web-core/widgets-native/flex/index.ts
@@ -124,13 +124,15 @@ export class Flex extends MultiChildWidget implements CssMinHeightMixin {
       ...css.justifyContent(this.mainAxisAlignment),
       "flex-direction": direction(this.direction),
       "align-items": flex_align_items(this.crossAxisAlignment),
-      flex: this.flex,
+      flex: this.flex > 0 ? this.flex : undefined,
       "flex-wrap": this.flexWrap,
       gap:
         // if justify-content is set to space-between, do not set the gap.
         this.mainAxisAlignment == MainAxisAlignment.spaceBetween
           ? undefined
-          : this.itemSpacing && css.px(this.itemSpacing),
+          : this.itemSpacing > 0
+          ? css.px(this.itemSpacing)
+          : undefined,
       "box-shadow": css.boxshadow(...(this.boxShadow ?? [])),
       ...css.border(this.border),
       ...css.borderRadius(this.borderRadius),

--- a/packages/builder-web-core/widgets-native/flex/index.ts
+++ b/packages/builder-web-core/widgets-native/flex/index.ts
@@ -123,10 +123,14 @@ export class Flex extends MultiChildWidget implements CssMinHeightMixin {
       overflow: this.overflow,
       ...css.justifyContent(this.mainAxisAlignment),
       "flex-direction": direction(this.direction),
-      "align-items": this.crossAxisAlignment,
+      "align-items": flex_align_items(this.crossAxisAlignment),
       flex: this.flex,
       "flex-wrap": this.flexWrap,
-      gap: this.itemSpacing && css.px(this.itemSpacing),
+      gap:
+        // if justify-content is set to space-between, do not set the gap.
+        this.mainAxisAlignment == MainAxisAlignment.spaceBetween
+          ? undefined
+          : this.itemSpacing && css.px(this.itemSpacing),
       "box-shadow": css.boxshadow(...(this.boxShadow ?? [])),
       ...css.border(this.border),
       ...css.borderRadius(this.borderRadius),
@@ -152,4 +156,25 @@ function direction(axis: Axis): CSSProperty.FlexDirection {
       return "column";
   }
   throw `axis value of "${axis}" is not a valid reflect Axis value.`;
+}
+
+/**
+ * explicit css value with `flex-` prefix for start, end
+ * why? - "start" and "end" also attributes to the box itself -> to be more flex-specific.
+ * @param alignment
+ * @returns
+ */
+function flex_align_items(alignment: CrossAxisAlignment) {
+  switch (alignment) {
+    case CrossAxisAlignment.start:
+      return "flex-start";
+    case CrossAxisAlignment.end:
+      return "flex-end";
+    case CrossAxisAlignment.center:
+      return "center";
+    case CrossAxisAlignment.stretch:
+      return "stretch";
+    case CrossAxisAlignment.baseline:
+      return "baseline";
+  }
 }

--- a/packages/builder-web-core/widgets-native/html-button/index.ts
+++ b/packages/builder-web-core/widgets-native/html-button/index.ts
@@ -179,17 +179,6 @@ export class HtmlButton extends Container implements IButtonStyleButton {
       ],
     };
   }
-
-  get finalStyle() {
-    const superstyl = super.finalStyle;
-
-    // width override. ------------------------------------------------------------------------------------------
-    return {
-      ...superstyl,
-      width: undefined,
-    };
-    // ----------------------------------------------------------------------------------------------------------
-  }
 }
 
 const _button_hover_style: CSSProperties = {

--- a/packages/builder-web-core/widgets-native/html-image/index.ts
+++ b/packages/builder-web-core/widgets-native/html-image/index.ts
@@ -3,39 +3,64 @@ import assert from "assert";
 import { JSX, JSXAttribute, StringLiteral } from "coli";
 import { StylableJSXElementConfig, WidgetKey, k } from "../..";
 import { SelfClosingContainer } from "../container";
+import {
+  BoxFit,
+  ImageRepeat,
+  cgr,
+  Alignment,
+  ImageManifest,
+} from "@reflect-ui/core";
 import * as css from "@web-builder/styles";
-export class ImageElement extends SelfClosingContainer {
+
+type HtmlImageElementProps = Omit<ImageManifest, "semanticLabel"> & {
+  alt?: string;
+};
+
+export class ImageElement
+  extends SelfClosingContainer
+  implements HtmlImageElementProps
+{
   _type = "img";
+
   readonly src: string;
-  readonly alt: string;
-  width: number;
-  height: number;
+  readonly width: number;
+  readonly height: number;
+  readonly alignment?: Alignment;
+  readonly centerSlice?: cgr.Rect;
+  readonly fit?: BoxFit;
+  readonly repeat?: ImageRepeat;
+  alt?: string;
 
   constructor({
     key,
     src,
-    alt,
     width,
     height,
+    alignment,
+    centerSlice,
+    fit,
+    repeat,
+    alt,
   }: {
     key: WidgetKey;
-    src: string;
-    alt?: string;
-    width?: number;
-    height?: number;
-  }) {
+  } & HtmlImageElementProps) {
     super({ key });
     assert(src !== undefined, "ImageElement requires src");
+
     this.src = src;
-    this.alt = alt;
     this.width = width;
     this.height = height;
+    this.alignment = alignment;
+    this.centerSlice = centerSlice;
+    this.fit = fit;
+    this.repeat = repeat;
+    this.alt = alt;
   }
 
   styleData() {
     return <CSSProperties>{
       ...super.styleData(),
-      "object-fit": "cover",
+      "object-fit": object_fit(this.fit) ?? "cover",
       width: css.px(this.width),
       height: css.px(this.height),
       // "max-width": "100%",
@@ -60,5 +85,27 @@ export class ImageElement extends SelfClosingContainer {
       tag: JSX.identifier("img"),
       attributes: attributes,
     };
+  }
+}
+
+function object_fit(fit?: BoxFit) {
+  switch (fit) {
+    case BoxFit.fill:
+      return "fill";
+    case BoxFit.contain:
+      return "contain";
+    case BoxFit.cover:
+      return "cover";
+    case BoxFit.none:
+      return "none";
+    case BoxFit.scaleDown:
+      return "scale-down";
+    case BoxFit.fitHeight:
+    case BoxFit.fitWidth:
+      // TODO:
+      return;
+    case undefined:
+    default:
+      return;
   }
 }

--- a/packages/builder-web-core/widgets-native/html-input/html-input-range.ts
+++ b/packages/builder-web-core/widgets-native/html-input/html-input-range.ts
@@ -100,14 +100,14 @@ export class HtmlInputRange extends Container implements ISliderManifest {
       "::-webkit-slider-thumb": this.thumbShape
         ? thumbstyle({
             ...this.thumbShape,
-            activeColor: this.activeColor,
+            color: this.thumbColor,
             platform: "webkit",
           })
         : undefined,
       "::-moz-range-thumb": this.thumbShape
         ? thumbstyle({
             ...this.thumbShape,
-            activeColor: this.activeColor,
+            color: this.thumbColor,
             platform: "moz",
           })
         : undefined,
@@ -179,18 +179,18 @@ export class HtmlSlider extends HtmlInputRange {}
 
 function thumbstyle({
   enabledThumbRadius,
-  activeColor,
+  color,
   platform,
 }: RoundSliderThumbShape & {
   platform: "moz" | "webkit";
 } & {
-  activeColor: Color;
+  color: Color;
 }): CSSProperties {
   const base: CSSProperties = <CSSProperties>{
     width: css.px(enabledThumbRadius),
     height: css.px(enabledThumbRadius),
     "border-radius": "50%",
-    "background-color": css.color(activeColor),
+    "background-color": css.color(color),
     // ..._aberation_support_progress_fill_dirty({ color: activeColor }),
     cursor: "pointer" /* Cursor on hover */,
   };

--- a/packages/builder-web-core/widgets-native/html-input/html-input-text.ts
+++ b/packages/builder-web-core/widgets-native/html-input/html-input-text.ts
@@ -151,7 +151,7 @@ export class HtmlInputText extends Container implements ITextFieldManifest {
       "text-align": this.textAlign,
       "text-decoration": css.textDecoration(this.style.decoration),
       "text-shadow": css.textShadow(this.style.textShadow),
-      "text-transform": this.style.textTransform,
+      "text-transform": css.textTransform(this.style.textTransform),
       // text styles --------------------------------------------
     };
   }

--- a/packages/builder-web-core/widgets-native/html-svg/index.ts
+++ b/packages/builder-web-core/widgets-native/html-svg/index.ts
@@ -200,6 +200,17 @@ export class SvgElement extends StylableJsxWidget {
     };
   }
 
+  // @override
+  get finalStyle() {
+    return {
+      ...super.finalStyle,
+      // TODO: this is a hot fix of svg & path's constraint handling
+      // width & height for the svg must be preserved. (it wont' follow the constraints anyway.)
+      width: css.length(this.width),
+      height: css.length(this.height),
+    };
+  }
+
   jsxConfig(): StylableJSXElementConfig | UnstylableJSXElementConfig {
     return <StylableJSXElementConfig>{
       type: "tag-and-attr",

--- a/packages/builder-web-core/widgets-native/html-svg/index.ts
+++ b/packages/builder-web-core/widgets-native/html-svg/index.ts
@@ -202,10 +202,12 @@ export class SvgElement extends StylableJsxWidget {
 
   // @override
   get finalStyle() {
+    const super_finalStyle = super.finalStyle;
     return {
-      ...super.finalStyle,
+      ...super_finalStyle,
       // TODO: this is a hot fix of svg & path's constraint handling
       // width & height for the svg must be preserved. (it wont' follow the constraints anyway.)
+      // it can also be 100%
       width: css.length(this.width),
       height: css.length(this.height),
     };

--- a/packages/builder-web-core/widgets-native/html-text-element/index.ts
+++ b/packages/builder-web-core/widgets-native/html-text-element/index.ts
@@ -73,7 +73,7 @@ export class Text extends TextChildWidget {
       "text-align": this.textAlign,
       "text-decoration": css.textDecoration(this.textStyle.decoration),
       "text-shadow": css.textShadow(this.textStyle.textShadow),
-      "text-transform": this.textStyle.textTransform,
+      "text-transform": css.textTransform(this.textStyle.textTransform),
       // ------------------------------------------
       ...textWH({ width: this.width, height: this.height }),
     };

--- a/packages/builder-web-core/widgets-native/html-text-element/index.ts
+++ b/packages/builder-web-core/widgets-native/html-text-element/index.ts
@@ -73,6 +73,7 @@ export class Text extends TextChildWidget {
       "text-align": this.textAlign,
       "text-decoration": css.textDecoration(this.textStyle.decoration),
       "text-shadow": css.textShadow(this.textStyle.textShadow),
+      "text-transform": this.textStyle.textTransform,
       // ------------------------------------------
       ...textWH({ width: this.width, height: this.height }),
     };

--- a/packages/builder-web-core/widgets-native/html-text-element/index.ts
+++ b/packages/builder-web-core/widgets-native/html-text-element/index.ts
@@ -14,7 +14,7 @@ import { Dynamic } from "@reflect-ui/core/lib/_utility-types";
  * You can select wich element to render with `elementPreference`. - choose between h1 ~ h6, p, span, etc.
  */
 export class Text extends TextChildWidget {
-  _type: "Text";
+  _type: "Text" = "Text";
 
   // text properties
   data: Dynamic<string>;
@@ -74,13 +74,25 @@ export class Text extends TextChildWidget {
       "text-decoration": css.textDecoration(this.textStyle.decoration),
       "text-shadow": css.textShadow(this.textStyle.textShadow),
       // ------------------------------------------
-      "min-height": css.px(this.height),
-      // TODO: do not specify width when parent is a flex container.
-      // Also flex: 1 is required to make the text wrap.
-      width: css.px(this.width),
+      ...textWH({ width: this.width, height: this.height }),
     };
 
     return <CSSProperties>textStyle;
+  }
+
+  get finalStyle() {
+    const superFinalStyle = super.finalStyle;
+    // TODO: this is a dirty fix ------------------------------------------------
+    // the text's width should not be overriden by the constraint's preference.
+    if (this.width === undefined) {
+      delete superFinalStyle["width"];
+    }
+    if (this.height === undefined) {
+      delete superFinalStyle["height"];
+    }
+    // --------------------------------------------------------------------------
+
+    return { ...superFinalStyle };
   }
 
   jsxConfig(): StylableJSXElementConfig {
@@ -99,3 +111,12 @@ const __get_dedicated_element_tag = (t?: WebTextElement | undefined) => {
     return __default_element_tag;
   }
 };
+
+function textWH({ width, height }: { width: number; height: number }) {
+  return {
+    // TODO: do not specify width when parent is a flex container.
+    // Also flex: 1 is required to make the text wrap.
+    width: css.px(width),
+    "min-height": css.px(height),
+  };
+}

--- a/packages/builder-web-core/widgets-native/html-text-element/index.ts
+++ b/packages/builder-web-core/widgets-native/html-text-element/index.ts
@@ -115,8 +115,8 @@ const __get_dedicated_element_tag = (t?: WebTextElement | undefined) => {
 
 function textWH({ width, height }: { width: number; height: number }) {
   return {
-    // TODO: do not specify width when parent is a flex container.
-    // Also flex: 1 is required to make the text wrap.
+    // TODO: do not specify width when parent is a flex container. (set as 100%)
+    // Also flex-grow: 1 is required to make the text wrap.
     width: css.px(width),
     "min-height": css.px(height),
   };

--- a/packages/builder-web-react/react-css-module-widget/react-css-module-module-builder.ts
+++ b/packages/builder-web-react/react-css-module-widget/react-css-module-module-builder.ts
@@ -18,7 +18,7 @@ import {
 import { JsxWidget } from "@web-builder/core";
 import {
   buildJsx,
-  getWidgetStylesConfigMap,
+  StylesConfigMapBuilder,
   JSXWithoutStyleElementConfig,
   JSXWithStyleElementConfig,
   WidgetStyleConfigMap,
@@ -34,7 +34,7 @@ import { react as react_config } from "@designto/config";
 export class ReactCssModuleBuilder {
   private readonly entry: JsxWidget;
   private readonly widgetName: string;
-  private readonly stylesConfigWidgetMap: WidgetStyleConfigMap;
+  private readonly stylesMapper: StylesConfigMapBuilder;
   private readonly namer: ScopedVariableNamer;
   readonly config: react_config.ReactCssModuleConfig;
 
@@ -51,17 +51,18 @@ export class ReactCssModuleBuilder {
       entry.key.id,
       ReservedKeywordPlatformPresets.react
     );
-    this.stylesConfigWidgetMap = getWidgetStylesConfigMap(entry, {
+    this.stylesMapper = new StylesConfigMapBuilder(entry, {
       namer: this.namer,
       rename_tag: false /** css-module tag shoule not be renamed */,
     });
+
     this.config = config;
   }
 
   private stylesConfig(
     id: string
   ): JSXWithStyleElementConfig | JSXWithoutStyleElementConfig {
-    return this.stylesConfigWidgetMap.get(id);
+    return this.stylesMapper.map.get(id);
   }
 
   private jsxBuilder(widget: JsxWidget) {

--- a/packages/builder-web-react/react-inline-css-widget/react-inline-css-module-builder.ts
+++ b/packages/builder-web-react/react-inline-css-widget/react-inline-css-module-builder.ts
@@ -8,7 +8,7 @@ import {
 } from "@web-builder/react-core";
 import {
   buildJsx,
-  getWidgetStylesConfigMap,
+  StylesConfigMapBuilder,
   JSXWithoutStyleElementConfig,
   JSXWithStyleElementConfig,
   WidgetStyleConfigMap,
@@ -44,7 +44,7 @@ export class ReactInlineCssBuilder {
   private readonly widgetName: string;
   readonly config: react_config.ReactInlineCssConfig;
   private readonly namer: ScopedVariableNamer;
-  private readonly stylesConfigWidgetMap: WidgetStyleConfigMap;
+  private readonly stylesMapper: StylesConfigMapBuilder;
 
   constructor({
     entry,
@@ -60,7 +60,8 @@ export class ReactInlineCssBuilder {
       entry.key.id,
       ReservedKeywordPlatformPresets.react
     );
-    this.stylesConfigWidgetMap = getWidgetStylesConfigMap(entry, {
+
+    this.stylesMapper = new StylesConfigMapBuilder(entry, {
       namer: this.namer,
       rename_tag: false,
     });
@@ -69,7 +70,7 @@ export class ReactInlineCssBuilder {
   private stylesConfig(
     id: string
   ): JSXWithStyleElementConfig | JSXWithoutStyleElementConfig {
-    return this.stylesConfigWidgetMap.get(id);
+    return this.stylesMapper.map.get(id);
   }
 
   private jsxBuilder(widget: JsxWidget) {

--- a/packages/builder-web-react/react-styled-component-widget/react-styled-components-module-builder.ts
+++ b/packages/builder-web-react/react-styled-component-widget/react-styled-components-module-builder.ts
@@ -15,7 +15,7 @@ import { BlockStatement, Import, ImportDeclaration, Return } from "coli";
 import { JsxWidget } from "@web-builder/core";
 import {
   buildJsx,
-  getWidgetStylesConfigMap,
+  StylesConfigMapBuilder,
   WidgetStyleConfigMap,
 } from "@web-builder/core/builders";
 import { react as react_config } from "@designto/config";
@@ -24,7 +24,7 @@ import { StyledComponentDeclaration } from "@web-builder/styled/styled-component
 export class ReactStyledComponentsBuilder {
   private readonly entry: JsxWidget;
   private readonly widgetName: string;
-  private readonly styledConfigWidgetMap: WidgetStyleConfigMap;
+  private readonly stylesMapper: StylesConfigMapBuilder;
   private readonly namer: ScopedVariableNamer;
   readonly config: react_config.ReactStyledComponentsConfig;
 
@@ -41,17 +41,19 @@ export class ReactStyledComponentsBuilder {
       entry.key.id,
       ReservedKeywordPlatformPresets.react
     );
-    this.styledConfigWidgetMap = getWidgetStylesConfigMap(entry, {
+
+    this.stylesMapper = new StylesConfigMapBuilder(entry, {
       namer: this.namer,
       rename_tag: true /** styled component tag shoule be renamed */,
     });
+
     this.config = config;
   }
 
   private styledConfig(
     id: string
   ): StyledComponentJSXElementConfig | NoStyleJSXElementConfig {
-    return this.styledConfigWidgetMap.get(id);
+    return this.stylesMapper.map.get(id);
   }
 
   private jsxBuilder(widget: JsxWidget) {
@@ -89,11 +91,10 @@ export class ReactStyledComponentsBuilder {
   }
 
   partDeclarations() {
-    return Array.from(this.styledConfigWidgetMap.keys())
+    return Array.from(this.stylesMapper.map.keys())
       .map((k) => {
-        return (
-          this.styledConfigWidgetMap.get(k) as StyledComponentJSXElementConfig
-        ).styledComponent;
+        return (this.stylesMapper.map.get(k) as StyledComponentJSXElementConfig)
+          .styledComponent;
       })
       .filter((s) => s);
   }

--- a/packages/builder-web-styled-components/optimization/duplicated-style-optimization.ts
+++ b/packages/builder-web-styled-components/optimization/duplicated-style-optimization.ts
@@ -1,0 +1,100 @@
+///
+/// General duplicated style optimization.
+/// this is based on static rule, based on the names of the layer and styles.
+///
+
+import type { ElementCssStyleData } from "@coli.codes/css";
+
+/// 1. based on final built style
+/// 2. based on pre-build style comparison
+/// - suggesting the merged style name
+
+interface MinimalStyleRepresenation {
+  name: string;
+  style: ElementCssStyleData;
+}
+
+type NameMatcher =
+  // /**
+  //  * provide a custom regex to compare two names
+  //  */
+  // | "custom-regex";
+  /**
+   * match exactly
+   */
+  | "exact"
+  /**
+   * allow matching with numbered suffix
+   * e.g.
+   * - 'Wrapper' = 'Wrapper1'
+   * - 'Container1' = 'Container2'
+   * - 'View' = 'View_001' = 'View_002'
+   */
+  | "suffix-number"
+  /**
+   * allow matching with separator (.-_) with following numbered suffix
+   * e.g.
+   * - 'Wrapper' = 'Wrapper-1'
+   * - 'Container' = 'Container.2'
+   * - 'View' = 'View_001' = 'View_002'
+   */
+  | "suffix-separator-number";
+
+function is_matching_name(a: string, b: string, matcher: NameMatcher) {
+  switch (matcher) {
+    case "exact":
+      return a === b;
+    case "suffix-number": {
+      // the suffix is optional.
+      // yes: 'Wrapper' = 'Wrapper1' = 'Wrapper2' = 'Wrapper002'
+      // no: 'Wrapper' !== 'Wrapper_001' !== 'Wrapper_A' !== 'Wrapper_A'
+
+      if (a.includes(b)) {
+        const suffix = a.replace(b, "");
+        return /(\d+)/.test(suffix);
+      } else if (b.includes(a)) {
+        const suffix = b.replace(a, "");
+        return /(\d+)/.test(suffix);
+      } else {
+        return false;
+      }
+    }
+
+    case "suffix-separator-number":
+      // allowed spearator is .. '.', '-', '_'
+      // yes: 'Wrapper' = 'Wrapper-1' = 'Wrapper.2' = 'Wrapper_001'
+      // no: 'Wrapper' !== 'Wrapper1' !== 'Wrapper2' !== 'Wrapper_A' !== 'Wrapper_A'
+
+      if (a.includes(b)) {
+        const suffix = a.replace(b, "");
+        return /^((\-|\.|\_)?\d+)$/.test(suffix);
+      } else if (b.includes(a)) {
+        const suffix = b.replace(a, "");
+        return /^((\-|\.|\_)?\d+)$/.test(suffix);
+      }
+      return false;
+  }
+}
+
+/**
+ * returns boolean based on input's name and style data. if both matches, return true.
+ * @param a 1st element
+ * @param b 2nd element
+ * @param options
+ * @returns
+ */
+export function is_duplicate_by_name_and_style(
+  a: MinimalStyleRepresenation,
+  b: MinimalStyleRepresenation,
+  options: {
+    name_match: NameMatcher;
+  }
+) {
+  // name should be the same
+  if (!is_matching_name(a.name, b.name, options.name_match)) {
+    return false;
+  }
+
+  // style should be the same
+  return JSON.stringify(a.style) === JSON.stringify(b.style);
+}

--- a/packages/builder-web-styled-components/optimization/duplicated-text-style-optimization.ts
+++ b/packages/builder-web-styled-components/optimization/duplicated-text-style-optimization.ts
@@ -1,0 +1,4 @@
+///
+/// Text style declaration optimization
+/// Clear the duplicated text styles, merge it into one.
+///

--- a/packages/builder-web-vanilla/export-inline-css-html-file/index.ts
+++ b/packages/builder-web-vanilla/export-inline-css-html-file/index.ts
@@ -7,7 +7,7 @@ import { ReservedKeywordPlatformPresets } from "@coli.codes/naming/reserved";
 import { k, JsxWidget } from "@web-builder/core";
 import {
   buildJsx,
-  getWidgetStylesConfigMap,
+  StylesConfigMapBuilder,
   JSXWithoutStyleElementConfig,
   JSXWithStyleElementConfig,
   WidgetStyleConfigMap,
@@ -58,10 +58,12 @@ export function export_inlined_css_html_file(
     ReservedKeywordPlatformPresets.html
   );
 
-  const styles_map: WidgetStyleConfigMap = getWidgetStylesConfigMap(widget, {
+  const mapper = new StylesConfigMapBuilder(widget, {
     namer: styledComponentNamer,
     rename_tag: false, // vanilla html tag will be preserved.
   });
+
+  const styles_map: WidgetStyleConfigMap = mapper.map;
 
   function getStyleConfigById(
     id: string

--- a/packages/designto-flutter/tokens-to-flutter-widget/index.ts
+++ b/packages/designto-flutter/tokens-to-flutter-widget/index.ts
@@ -14,6 +14,8 @@ import {
   handle_flutter_case_no_size_stack_children,
 } from "../case-handling";
 import { rd } from "../_utils";
+import assert from "assert";
+import { WrappingContainer } from "@designto/token/tokens";
 
 export function buildFlutterWidgetFromTokens(
   widget: core.DefaultStyleWidget
@@ -33,6 +35,8 @@ function compose(
   widget: core.DefaultStyleWidget,
   context: { is_root: boolean }
 ) {
+  assert(widget, "input widget is required");
+
   const handleChildren = (
     children: core.DefaultStyleWidget[]
   ): flutter.Widget[] => {
@@ -55,6 +59,9 @@ function compose(
     ..._remove_width_height_if_root_wh,
   };
 
+  //   const _key = keyFromWidget(widget);
+  let thisFlutterWidget: flutter.Widget;
+
   const flex_props = (f: core.Flex) => {
     return {
       mainAxisAlignment: rendering.mainAxisAlignment(f.mainAxisAlignment),
@@ -63,9 +70,7 @@ function compose(
       verticalDirection: painting.verticalDirection(f.verticalDirection),
     };
   };
-  //   const _key = keyFromWidget(widget);
 
-  let thisFlutterWidget: flutter.Widget;
   if (widget instanceof core.Column) {
     const children = compose_item_spacing_children(widget.children, {
       itemspacing: widget.itemSpacing,
@@ -106,13 +111,15 @@ function compose(
     });
   } else if (widget instanceof core.Flex) {
     // FIXME: FLEX not supported yet.
-    // thisFlutterWidget = new flutter.Flex({
-    //   //   direction: widget.direction,
-    //   //   ...widget,
-    //   //   ...default_props_for_layout,
-    //   children: handleChildren(widget.children),
-    //   //   key: _key,
-    // });
+    thisFlutterWidget = new flutter.Flex({
+      ...widget,
+      ...default_props_for_layout,
+      ...flex_props(widget),
+      clipBehavior: null,
+      direction: painting.axis(widget.direction),
+      children: handleChildren(widget.children),
+      //   key: _key,
+    });
   } else if (widget instanceof core.Stack) {
     const _remove_overflow_if_root_overflow = {
       clipBehavior: context.is_root
@@ -163,29 +170,29 @@ function compose(
       }
       // -------------------------------------
     }
+  } else if (widget instanceof core.SizedBox) {
+    //
+  } else if (widget instanceof core.OverflowBox) {
+    //
   } else if (widget instanceof core.Opacity) {
     thisFlutterWidget = new flutter.Opacity({
       opacity: widget.opacity,
       child: handleChild(widget.child),
     });
+  } else if (widget instanceof core.Blurred) {
+    // FIXME: blur flutter control
+    //   const isBlurVisibile = widget.blur.visible;
+    //   if (isBlurVisibile) {
+    //     if (widget.blur.type === "LAYER_BLUR") {
+    //     } else if (widget.blur.type === "BACKGROUND_BLUR") {
+    //     }
+    //   }
   } else if (widget instanceof core.Rotation) {
     thisFlutterWidget = flutter.Transform.rotate({
       angle: widget.rotation,
       child: handleChild(widget.child),
     });
   }
-
-  // FIXME: blur flutter control
-  // else if (widget instanceof core.Blurred) {
-  //   const isBlurVisibile = widget.blur.visible;
-  //   if (isBlurVisibile) {
-
-  //     if (widget.blur.type === "LAYER_BLUR") {
-
-  //     } else if (widget.blur.type === "BACKGROUND_BLUR") {
-  //     }
-  //   }
-  // }
 
   // ----- region clip path ------
   else if (widget instanceof core.ClipRRect) {
@@ -252,6 +259,41 @@ function compose(
       }
     }
   }
+
+  // #region component widgets
+  // button
+  else if (widget instanceof core.ButtonStyleButton) {
+    // TODO: widget.icon - not supported
+    // thisFlutterWidget = compose_unwrapped_button(_key, widget);
+  }
+  // textfield
+  else if (widget instanceof core.TextField) {
+    // thisFlutterWidget = compose_unwrapped_text_input(_key, widget);
+  } else if (widget instanceof core.Slider) {
+    // thisFlutterWidget = compose_unwrapped_slider(_key, widget);
+  }
+  // wrapping container
+  else if (widget instanceof WrappingContainer) {
+    // #region
+    // mergable widgets for web
+    // if (widget.child instanceof core.TextField) {
+    //   thisFlutterWidget = compose_unwrapped_text_input(
+    //     _key,
+    //     widget.child,
+    //     widget
+    //   );
+    // } else if (widget.child instanceof core.ButtonStyleButton) {
+    //   thisFlutterWidget = compose_unwrapped_button(_key, widget.child, widget);
+    // } else if (widget.child instanceof core.Slider) {
+    //   thisFlutterWidget = compose_unwrapped_slider(_key, widget.child, widget);
+    // } else {
+    //   throw new Error(
+    //     `Unsupported widget type: ${widget.child.constructor.name}`
+    //   );
+    // }
+    // #endregion
+  }
+  // #endregion
 
   // execution order matters - some above widgets inherits from Container, this shall be handled at the last.
   else if (widget instanceof core.Container) {

--- a/packages/designto-token/detection/do-have-flex.ts
+++ b/packages/designto-token/detection/do-have-flex.ts
@@ -1,0 +1,5 @@
+import type { ReflectSceneNode } from "@design-sdk/figma-node";
+
+export function hasFlexible(node: ReflectSceneNode) {
+  return node.layoutGrow >= 1;
+}

--- a/packages/designto-token/detection/index.ts
+++ b/packages/designto-token/detection/index.ts
@@ -1,3 +1,4 @@
+export * from "./do-have-flex";
 export * from "./do-contains-masking";
 export * from "./do-have-dimmed-opacity";
 export * from "./do-have-stretching";

--- a/packages/designto-token/main.ts
+++ b/packages/designto-token/main.ts
@@ -329,7 +329,7 @@ function handle_by_types(
         tokenizedTarget = tokenizeContainer.fromEllipse(node);
       } else {
         // a customized ellipse, most likely to be part of a graphical element.
-        tokenizedTarget = tokenizeGraphics.fromAnyNode(node);
+        tokenizedTarget = tokenizeGraphics.fromIrregularEllipse(node);
       }
       break;
 

--- a/packages/designto-token/main.ts
+++ b/packages/designto-token/main.ts
@@ -1,5 +1,5 @@
 import { nodes } from "@design-sdk/core";
-import { Widget } from "@reflect-ui/core";
+import { Expanded, Widget } from "@reflect-ui/core";
 import type { Blurred, Opacity, Rotation } from "@reflect-ui/core";
 import type { Stretched } from "./tokens";
 import { tokenizeText } from "./token-text";
@@ -21,6 +21,7 @@ import {
   hasLayerBlurType,
   hasRotation,
   hasStretching,
+  hasFlexible,
 } from "./detection";
 import { MaskingItemContainingNode, tokenizeMasking } from "./token-masking";
 import { wrap_with_opacity } from "./token-opacity";
@@ -28,6 +29,7 @@ import { wrap_with_stretched } from "./token-stretch";
 import { wrap_with_layer_blur } from "./token-effect/layer-blur";
 import { wrap_with_background_blur } from "./token-effect/background-blur";
 import { wrap_with_rotation } from "./token-rotation";
+import { wrap_with_expanded } from "./token-expanded";
 import flags_handling_gate from "./support-flags";
 
 export type { Widget };
@@ -239,12 +241,15 @@ function handleNode(
 export function post_wrap(
   node: nodes.ReflectSceneNode,
   tokenizedTarget: Widget
-): Widget | Stretched | Opacity | Blurred | Rotation {
+): Widget | Stretched | Opacity | Blurred | Rotation | Expanded {
   let wrapped = tokenizedTarget;
-  if (wrapped) {
-    if (hasStretching(node)) {
-      wrapped = wrap_with_stretched(node, wrapped);
-    }
+
+  if (hasStretching(node)) {
+    wrapped = wrap_with_stretched(node, wrapped);
+  }
+
+  if (hasFlexible(node)) {
+    wrapped = wrap_with_expanded(node, wrapped);
   }
 
   if (hasDimmedOpacity(node)) {

--- a/packages/designto-token/main.ts
+++ b/packages/designto-token/main.ts
@@ -1,5 +1,7 @@
 import { nodes } from "@design-sdk/core";
 import { Widget } from "@reflect-ui/core";
+import type { Blurred, Opacity, Rotation } from "@reflect-ui/core";
+import type { Stretched } from "./tokens";
 import { tokenizeText } from "./token-text";
 import { tokenizeLayout } from "./token-layout";
 import { tokenizeContainer } from "./token-container";
@@ -167,10 +169,11 @@ function handleNode(
     }
 
     // - button -
-    const _detect_if_button = detectIf.button(node);
-    if (_detect_if_button.result) {
-      return tokenizeButton.fromManifest(node, _detect_if_button.data);
-    }
+    // TODO: this causes confliction with flags
+    // const _detect_if_button = detectIf.button(node);
+    // if (_detect_if_button.result) {
+    //   return tokenizeButton.fromManifest(node, _detect_if_button.data);
+    // }
   }
   // -------------------------------------------------------------------------
   // --------------------------- Detected tokens -----------------------------
@@ -233,33 +236,37 @@ function handleNode(
   return tokenizedTarget;
 }
 
-function post_wrap(node: nodes.ReflectSceneNode, tokenizedTarget: Widget) {
-  if (tokenizedTarget) {
+export function post_wrap(
+  node: nodes.ReflectSceneNode,
+  tokenizedTarget: Widget
+): Widget | Stretched | Opacity | Blurred | Rotation {
+  let wrapped = tokenizedTarget;
+  if (wrapped) {
     if (hasStretching(node)) {
-      tokenizedTarget = wrap_with_stretched(node, tokenizedTarget);
+      wrapped = wrap_with_stretched(node, wrapped);
     }
   }
 
   if (hasDimmedOpacity(node)) {
-    tokenizedTarget = wrap_with_opacity(node, tokenizedTarget);
+    wrapped = wrap_with_opacity(node, wrapped);
   }
 
   node.effects.map((d) => {
     const blurEffect = hasBlurType(d);
     if (blurEffect) {
       if (hasLayerBlurType(blurEffect)) {
-        tokenizedTarget = wrap_with_layer_blur(node, tokenizedTarget);
+        wrapped = wrap_with_layer_blur(node, wrapped);
       } else if (hasBackgroundBlurType(blurEffect)) {
-        tokenizedTarget = wrap_with_background_blur(node, tokenizedTarget);
+        wrapped = wrap_with_background_blur(node, wrapped);
       }
     }
   });
 
   if (hasRotation(node)) {
-    tokenizedTarget = wrap_with_rotation(node, tokenizedTarget);
+    wrapped = wrap_with_rotation(node, wrapped);
   }
 
-  return tokenizedTarget;
+  return wrapped;
 }
 
 function handle_by_types(

--- a/packages/designto-token/main.ts
+++ b/packages/designto-token/main.ts
@@ -306,7 +306,13 @@ function handle_by_types(
       break;
 
     case nodes.ReflectSceneNodeType.ellipse:
-      tokenizedTarget = tokenizeContainer.fromEllipse(node);
+      if (node.arcData.startingAngle === 0 && node.arcData.innerRadius === 0) {
+        // a standard ellipse
+        tokenizedTarget = tokenizeContainer.fromEllipse(node);
+      } else {
+        // a customized ellipse, most likely to be part of a graphical element.
+        tokenizedTarget = tokenizeGraphics.fromAnyNode(node);
+      }
       break;
 
     case nodes.ReflectSceneNodeType.boolean_operation:

--- a/packages/designto-token/main.ts
+++ b/packages/designto-token/main.ts
@@ -314,11 +314,9 @@ function handle_by_types(
       break;
 
     case nodes.ReflectSceneNodeType.line:
-      // FIXME: this is a temporary fallback. line should be handled with unique handler. (using rect's handler instead.)
-      tokenizedTarget = tokenizeContainer.fromRectangle(node as any);
+      tokenizedTarget = tokenizeContainer.fromLine(node as any);
+      // tokenizedTarget = tokenizeDivider.fromLine(_line);
       break;
-    // const _line = node as nodes.ReflectLineNode;
-    // tokenizedTarget = tokenizeDivider.fromLine(_line);
 
     default:
       console.error(`${node["type"]} is not yet handled by "@designto/token"`);

--- a/packages/designto-token/main.ts
+++ b/packages/designto-token/main.ts
@@ -273,9 +273,14 @@ function handle_by_types(
       // FIXME: aberation handling (remove me if required) --------------------------------
       // FIXME: this is for giving extra space for text so it won't break line accidently.
       // FIXME: consider applying this only to a preview build
-      if (node.data.length <= 6 && node.data.length > 2) {
+      // TODO: change logic to word count.
+      const wordcount = node.data.split(" ").length;
+      const txtlen = node.data.length;
+      if (wordcount <= 1) {
+        /* skip, since there is no word break */
+      } else if (txtlen <= 6 && wordcount <= 2) {
         node.width = node.width + 1;
-      } else if (node.data.length < 30) {
+      } else if (txtlen < 30) {
         node.width = node.width + 2;
       }
       // FIXME: ---------------------------------------------------------------------------------

--- a/packages/designto-token/main.ts
+++ b/packages/designto-token/main.ts
@@ -270,6 +270,16 @@ function handle_by_types(
       break;
 
     case nodes.ReflectSceneNodeType.text:
+      // FIXME: aberation handling (remove me if required) --------------------------------
+      // FIXME: this is for giving extra space for text so it won't break line accidently.
+      // FIXME: consider applying this only to a preview build
+      if (node.data.length <= 6 && node.data.length > 2) {
+        node.width = node.width + 1;
+      } else if (node.data.length < 30) {
+        node.width = node.width + 2;
+      }
+      // FIXME: ---------------------------------------------------------------------------------
+
       tokenizedTarget = tokenizeText.fromText(node as nodes.ReflectTextNode);
       break;
 

--- a/packages/designto-token/support-flags/index.ts
+++ b/packages/designto-token/support-flags/index.ts
@@ -23,6 +23,7 @@ export default function handleWithFlags(node: ReflectSceneNode) {
 }
 
 function _handle_with_flags(node, flags: FlagsParseResult) {
+  // #region widget altering flags
   // artwork
   const artwork_flag_alias =
     flags["artwork"] ||
@@ -44,6 +45,20 @@ function _handle_with_flags(node, flags: FlagsParseResult) {
     return tokenize_flagged_wrap(node, wrap_flag_alias);
   }
 
+  if (flags.__meta?.contains_button_flag) {
+    return tokenize_flagged_button(node, flags[keys.flag_key__as_button]);
+  }
+
+  if (flags.__meta?.contains_input_flag) {
+    return tokenize_flagged_textfield(node, flags[keys.flag_key__as_input]);
+  }
+
+  if (flags.__meta?.contains_slider_flag) {
+    return tokenize_flagged_slider(node, flags[keys.flag_key__as_slider]);
+  }
+  // #endregion
+
+  // #region element altering flags
   // heading
   const heading_flag_alias =
     flags[keys.flag_key__as_h1] ||
@@ -61,7 +76,9 @@ function _handle_with_flags(node, flags: FlagsParseResult) {
   if (span_flag_alias) {
     return tokenize_flagged_span(node, span_flag_alias);
   }
+  // #endregion
 
+  // #region style extension flags
   const paragraph_flag_alias = flags[keys.flag_key__as_p];
   if (paragraph_flag_alias) {
     return tokenize_flagged_paragraph(node, paragraph_flag_alias);
@@ -87,16 +104,5 @@ function _handle_with_flags(node, flags: FlagsParseResult) {
   if (fix_wh_flags.length) {
     return tokenize_flagged_fix_wh(node, fix_wh_flags);
   }
-
-  if (flags.__meta?.contains_button_flag) {
-    return tokenize_flagged_button(node, flags[keys.flag_key__as_button]);
-  }
-
-  if (flags.__meta?.contains_input_flag) {
-    return tokenize_flagged_textfield(node, flags[keys.flag_key__as_input]);
-  }
-
-  if (flags.__meta?.contains_slider_flag) {
-    return tokenize_flagged_slider(node, flags[keys.flag_key__as_slider]);
-  }
+  // #endregion style extension flags
 }

--- a/packages/designto-token/support-flags/token-button/index.ts
+++ b/packages/designto-token/support-flags/token-button/index.ts
@@ -7,11 +7,12 @@ import type {
 } from "@design-sdk/figma-node";
 import assert from "assert";
 import { tokenizeButton } from "../../token-widgets";
+import { WrappingContainer } from "../../tokens";
 
 export function tokenize_flagged_button(
   node: ReflectSceneNode,
   flag: AsButtonFlag
-): ButtonStyleButton | Container<ButtonStyleButton> {
+): ButtonStyleButton | WrappingContainer<ButtonStyleButton> {
   if (flag.value === false) return;
 
   const validated = validate_button(node);

--- a/packages/designto-token/support-flags/token-slider/index.ts
+++ b/packages/designto-token/support-flags/token-slider/index.ts
@@ -5,12 +5,10 @@ import type {
   ReflectFrameNode,
   ReflectRectangleNode,
   ReflectSceneNode,
-  ReflectTextNode,
 } from "@design-sdk/figma-node";
 import { keyFromNode } from "../../key";
 import assert from "assert";
 import { tokenizeLayout } from "../../token-layout";
-import { paintToColor } from "@design-sdk/core/utils/colors";
 import { unwrappedChild } from "../../wrappings";
 import { RoundSliderThumbShape } from "@reflect-ui/core/lib/slider.thumb";
 
@@ -45,6 +43,9 @@ export function tokenize_flagged_slider(
       case "frame-as-slider": {
         const { slider_root, thumb, value } = validated;
 
+        // TODO: use theme color as default if non available
+        const fallbackcolor = Colors.blue;
+
         // initial value -----------------------------
         const p_w = slider_root.width;
         const v_w = value?.width ?? 0;
@@ -53,17 +54,16 @@ export function tokenize_flagged_slider(
           Math.round((v_w / p_w + Number.EPSILON) * 100) / 100;
         // -------------------------------------------
 
-        // active color ------------------------------
-        // TODO: use theme color as default if non available
-        const _activecolor = value?.primaryColor ?? Colors.blue;
-        // -------------------------------------------
-
         // thumb style -------------------------------
-        const _thumbcolor = thumb?.primaryColor ?? Colors.blue;
+        const _thumbcolor = thumb.primaryColor ?? fallbackcolor;
         // currently only round thumb is supported
         const _thumbsize =
           Math.max(thumb?.height ?? 0, thumb?.width ?? 0) ?? undefined;
-        const _thumbelevation = thumb?.primaryShadow?.blurRadius ?? undefined;
+        const _thumbelevation = thumb.primaryShadow?.blurRadius ?? undefined;
+        // -------------------------------------------
+
+        // active color ------------------------------
+        const _activecolor = value?.primaryColor ?? fallbackcolor;
         // -------------------------------------------
 
         const container = unwrappedChild(
@@ -147,6 +147,8 @@ function validate_slider(node: ReflectSceneNode):
         const _3 = n.width === n.height;
         return _0 && _1 && _2 && _3;
       });
+
+      assert(thumb, "thumb node is required. no qualified node found.");
 
       const value = node.grandchildren
         .filter((n) => n.id !== thumb?.id)

--- a/packages/designto-token/support-flags/token-slider/index.ts
+++ b/packages/designto-token/support-flags/token-slider/index.ts
@@ -11,6 +11,7 @@ import assert from "assert";
 import { tokenizeLayout } from "../../token-layout";
 import { unwrappedChild } from "../../wrappings";
 import { RoundSliderThumbShape } from "@reflect-ui/core/lib/slider.thumb";
+import { WrappingContainer } from "../../tokens";
 
 /**
  *
@@ -32,7 +33,7 @@ import { RoundSliderThumbShape } from "@reflect-ui/core/lib/slider.thumb";
 export function tokenize_flagged_slider(
   node: ReflectSceneNode,
   flag: AsSliderFlag
-): Slider | Container {
+): Slider | WrappingContainer {
   if (flag.value === false) return;
 
   const validated = validate_slider(node);
@@ -75,9 +76,9 @@ export function tokenize_flagged_slider(
           )
         ) as Container;
 
-        // @ts-ignore FIXME: no tsignore
-        return new Container({
+        return new WrappingContainer({
           ...container,
+          key: keyFromNode(node),
           child: new Slider({
             key: _key,
             ...container,

--- a/packages/designto-token/support-flags/token-textfield/index.ts
+++ b/packages/designto-token/support-flags/token-textfield/index.ts
@@ -19,6 +19,7 @@ import { detectIf } from "@reflect-ui/detection";
 import { paintToColor } from "@design-sdk/core/utils/colors";
 import { tokenizeLayout } from "../../token-layout";
 import { unwrappedChild } from "../../wrappings";
+import { WrappingContainer } from "../../tokens";
 
 /**
  *
@@ -40,7 +41,7 @@ import { unwrappedChild } from "../../wrappings";
 export function tokenize_flagged_textfield(
   node: ReflectSceneNode,
   flag: AsInputFlag
-): TextField | Container {
+): TextField | WrappingContainer {
   if (flag.value === false) return;
 
   const validated = validate_input(node);
@@ -76,9 +77,9 @@ export function tokenize_flagged_textfield(
           )
         ) as Container;
 
-        // @ts-ignore FIXME: no tsignore
-        return new Container({
+        return new WrappingContainer({
           ...container,
+          key: keyFromNode(node),
           child: new TextField({
             key: _key,
             ...container,

--- a/packages/designto-token/support-flags/token-textfield/index.ts
+++ b/packages/designto-token/support-flags/token-textfield/index.ts
@@ -59,7 +59,7 @@ export function tokenize_flagged_textfield(
 
         // if value only contains '●' or '·' - e.g. ● ● ● ● ● ● it is safe to be casted as a password input.
         const obscureText = /^[·\|●\s]+$/.test(
-          (value.data || placeholder.data) ?? ""
+          (value?.data || placeholder?.data) ?? ""
         );
 
         const fillcolor =
@@ -83,7 +83,7 @@ export function tokenize_flagged_textfield(
             key: _key,
             ...container,
             obscureText: obscureText,
-            initialValue: value.data,
+            initialValue: value?.data,
             style: style || placeholderStyle,
             decoration: new TextFieldDecoration({
               border: new OutlineInputBorder({
@@ -190,4 +190,4 @@ function validate_input(node: ReflectSceneNode):
 }
 
 const valid_text_node = (node: ReflectSceneNode) =>
-  node.type === "TEXT" && node.visible && node.data.length >= 0;
+  node && node.type === "TEXT" && node.visible && node.data.length >= 0;

--- a/packages/designto-token/support-flags/token-textfield/index.ts
+++ b/packages/designto-token/support-flags/token-textfield/index.ts
@@ -62,6 +62,11 @@ export function tokenize_flagged_textfield(
           (value.data || placeholder.data) ?? ""
         );
 
+        const fillcolor =
+          input_root.primaryFill.type === "SOLID"
+            ? paintToColor(input_root.primaryFill)
+            : null;
+
         const container = unwrappedChild(
           tokenizeLayout.fromFrame(
             input_root,
@@ -78,17 +83,16 @@ export function tokenize_flagged_textfield(
             key: _key,
             ...container,
             obscureText: obscureText,
+            initialValue: value.data,
             style: style || placeholderStyle,
             decoration: new TextFieldDecoration({
               border: new OutlineInputBorder({
-                borderSide: container.border.bottom,
+                borderSide: container.border?.bottom,
                 borderRadius: container.borderRadius,
               }),
               contentPadding: input_root.padding,
-              fillColor:
-                input_root.primaryFill.type === "SOLID"
-                  ? paintToColor(input_root.primaryFill)
-                  : null,
+              filled: fillcolor ? true : false,
+              fillColor: fillcolor,
               placeholderText: placeholder?.data,
               placeholderStyle: placeholderStyle,
               //

--- a/packages/designto-token/support-flags/token-textfield/index.ts
+++ b/packages/designto-token/support-flags/token-textfield/index.ts
@@ -56,6 +56,12 @@ export function tokenize_flagged_textfield(
         const placeholderStyle =
           placeholder &&
           (tokenizeText.fromText(placeholder).style as TextStyle);
+
+        // if value only contains '●' or '·' - e.g. ● ● ● ● ● ● it is safe to be casted as a password input.
+        const obscureText = /^[·\|●\s]+$/.test(
+          (value.data || placeholder.data) ?? ""
+        );
+
         const container = unwrappedChild(
           tokenizeLayout.fromFrame(
             input_root,
@@ -71,6 +77,7 @@ export function tokenize_flagged_textfield(
           child: new TextField({
             key: _key,
             ...container,
+            obscureText: obscureText,
             style: style || placeholderStyle,
             decoration: new TextFieldDecoration({
               border: new OutlineInputBorder({

--- a/packages/designto-token/token-border/index.ts
+++ b/packages/designto-token/token-border/index.ts
@@ -1,7 +1,11 @@
 import { retrievePrimaryColor } from "@design-sdk/core/utils";
-import type { ReflectSceneNode, ReflectLineNode } from "@design-sdk/figma-node";
+import type {
+  ReflectSceneNode,
+  ReflectLineNode,
+  IReflectGeometryMixin,
+} from "@design-sdk/figma-node";
 import { Figma } from "@design-sdk/figma-types"; /** remove figma dependency */
-import { Border } from "@reflect-ui/core";
+import { Border, BorderStyle } from "@reflect-ui/core";
 import { roundNumber } from "@reflect-ui/uiutils";
 
 function fromLineNode(node: ReflectLineNode) {
@@ -11,14 +15,18 @@ function fromLineNode(node: ReflectLineNode) {
   }
   // guard invisible borders
   if (strokes.filter(visible).length > 0) {
+    const _p_stroke = strokes.find(visible);
+
     // generate the border, when it should exist
     // if width is 0, then we don't want to generate a border
     return node.strokeWeight
       ? new Border({
           // it's a line so we only add border to a single side.
           top: {
-            color: retrievePrimaryColor(strokes),
+            color: retrievePrimaryColor([_p_stroke]),
             width: node.strokeWeight, // do not round number
+            // the dashed border support is incomplete. we cannot support dashed gap since the platform does not support it.
+            style: isDashed(node) ? BorderStyle.dashed : BorderStyle.solid,
           },
         })
       : undefined;
@@ -33,6 +41,8 @@ function fromNode(node: ReflectSceneNode) {
     if ("strokeWeight" in node) {
       return fromStrokes(node.strokes, {
         width: node.strokeWeight,
+        // the dashed border support is incomplete. we cannot support dashed gap since the platform does not support it.
+        dashed: isDashed(node),
       });
     }
   }
@@ -42,27 +52,44 @@ function fromStrokes(
   strokes: ReadonlyArray<Figma.Paint>,
   {
     width,
+    dashed,
   }: {
     /**
      * a stroke height
      */
     width: number;
+    dashed: boolean;
   }
 ) {
   // guard invisible borders
   if (strokes.filter(visible).length > 0) {
     // generate the border, when it should exist
     // if width is 0, then we don't want to generate a border
+    // using the first stroke. since css3 standard does not support multiple borders (as well as flutter)
+    const _p_stroke = strokes.find(visible);
     return width
       ? Border.all({
-          color: retrievePrimaryColor(strokes),
+          color: retrievePrimaryColor([_p_stroke]),
           width: roundNumber(width),
+          style: dashed ? BorderStyle.dashed : BorderStyle.solid,
         })
       : undefined;
   }
 }
 
 const visible = (s) => s.visible;
+
+/**
+ *
+ * returns if the node's border is dashed or not
+ *
+ * - when solid, the dashPattern is empty - `[]`
+ * - when dashed, the dashPattern will be like - `[6, 6]`
+ * @param s
+ * @returns
+ */
+const isDashed = (s: IReflectGeometryMixin): boolean =>
+  s.dashPattern?.length > 0;
 
 export const tokenizeBorder = {
   fromStrokes: fromStrokes,

--- a/packages/designto-token/token-border/index.ts
+++ b/packages/designto-token/token-border/index.ts
@@ -1,8 +1,29 @@
 import { retrievePrimaryColor } from "@design-sdk/core/utils";
-import { ReflectSceneNode } from "@design-sdk/figma-node";
+import type { ReflectSceneNode, ReflectLineNode } from "@design-sdk/figma-node";
 import { Figma } from "@design-sdk/figma-types"; /** remove figma dependency */
 import { Border } from "@reflect-ui/core";
 import { roundNumber } from "@reflect-ui/uiutils";
+
+function fromLineNode(node: ReflectLineNode) {
+  const strokes = node.strokes;
+  if (!strokes || strokes.length === 0) {
+    return undefined;
+  }
+  // guard invisible borders
+  if (strokes.filter(visible).length > 0) {
+    // generate the border, when it should exist
+    // if width is 0, then we don't want to generate a border
+    return node.strokeWeight
+      ? new Border({
+          // it's a line so we only add border to a single side.
+          top: {
+            color: retrievePrimaryColor(strokes),
+            width: node.strokeWeight, // do not round number
+          },
+        })
+      : undefined;
+  }
+}
 
 function fromNode(node: ReflectSceneNode) {
   if ("strokes" in node) {
@@ -29,7 +50,7 @@ function fromStrokes(
   }
 ) {
   // guard invisible borders
-  if (strokes.filter((s) => s.visible).length > 0) {
+  if (strokes.filter(visible).length > 0) {
     // generate the border, when it should exist
     // if width is 0, then we don't want to generate a border
     return width
@@ -41,7 +62,10 @@ function fromStrokes(
   }
 }
 
+const visible = (s) => s.visible;
+
 export const tokenizeBorder = {
   fromStrokes: fromStrokes,
   fromNode: fromNode,
+  fromLineNode: fromLineNode,
 };

--- a/packages/designto-token/token-container/index.ts
+++ b/packages/designto-token/token-container/index.ts
@@ -4,7 +4,7 @@ import { tokenizeBackground } from "../token-background";
 import { BoxShape } from "@reflect-ui/core/lib/box-shape";
 import { keyFromNode } from "../key";
 import { tokenizeBorder } from "../token-border";
-import { BoxShadowManifest } from "@reflect-ui/core";
+import { BorderRadius, BoxShadowManifest } from "@reflect-ui/core";
 
 function fromRectangle(rect: nodes.ReflectRectangleNode): core.Container {
   const container = new core.Container({
@@ -30,7 +30,7 @@ function fromEllipse(ellipse: nodes.ReflectEllipseNode): core.Container {
     height: ellipse.height,
     boxShadow: ellipse.shadows as BoxShadowManifest[],
     border: tokenizeBorder.fromNode(ellipse),
-    borderRadius: { all: Math.max(ellipse.width, ellipse.height) / 2 },
+    borderRadius: BorderRadius.all({ x: ellipse.width, y: ellipse.height }), // this is equivalant to css "50%"
     background: tokenizeBackground.fromFills(ellipse.fills),
   });
 

--- a/packages/designto-token/token-container/index.ts
+++ b/packages/designto-token/token-container/index.ts
@@ -23,6 +23,20 @@ function fromRectangle(rect: nodes.ReflectRectangleNode): core.Container {
   return container;
 }
 
+function fromLine(line: nodes.ReflectLineNode): core.Container {
+  const container = new core.Container({
+    key: keyFromNode(line),
+    width: line.width,
+    height: 0,
+    boxShadow: line.shadows as BoxShadowManifest[],
+    border: tokenizeBorder.fromLineNode(line),
+  });
+
+  container.x = line.x;
+  container.y = line.y;
+  return container;
+}
+
 function fromEllipse(ellipse: nodes.ReflectEllipseNode): core.Container {
   const container = new core.Container({
     key: keyFromNode(ellipse),
@@ -45,4 +59,5 @@ function fromEllipse(ellipse: nodes.ReflectEllipseNode): core.Container {
 export const tokenizeContainer = {
   fromRectangle: fromRectangle,
   fromEllipse: fromEllipse,
+  fromLine: fromLine,
 };

--- a/packages/designto-token/token-expanded/index.ts
+++ b/packages/designto-token/token-expanded/index.ts
@@ -1,0 +1,23 @@
+import { nodes } from "@design-sdk/core";
+import { Expanded, WidgetKey } from "@reflect-ui/core";
+import type { Widget } from "@reflect-ui/core";
+import assert from "assert";
+
+export function wrap_with_expanded(
+  node: nodes.ReflectSceneNode,
+  widget: Widget
+): Expanded {
+  assert(
+    node.layoutGrow >= 1,
+    "layoug grow must be >= 1 to be wrapped with Expanded"
+  );
+
+  return new Expanded({
+    key: new WidgetKey({
+      ...widget.key,
+      id: widget.key.id + "_opacity",
+    }),
+    child: widget,
+    flex: node.layoutGrow,
+  });
+}

--- a/packages/designto-token/token-graphics/bitmap.ts
+++ b/packages/designto-token/token-graphics/bitmap.ts
@@ -1,11 +1,17 @@
 import { MainImageRepository } from "@design-sdk/core/assets-repository";
 import type {
   ReflectBooleanOperationNode,
+  ReflectEllipseNode,
   ReflectSceneNode,
 } from "@design-sdk/figma-node";
-import { ImageWidget } from "@reflect-ui/core";
+import { BoxFit, ImageWidget } from "@reflect-ui/core";
 import { ImagePaint } from "@reflect-ui/core/lib/cgr";
 import { keyFromNode } from "../key";
+
+/**
+ * @deprecated TODO: update the asset repository pattern.
+ */
+const _asset_key = "fill-later-assets";
 
 function fromStar(): ImageWidget {
   // return new ImageWidget();
@@ -33,11 +39,9 @@ function fromFrame(): ImageWidget {
 }
 
 function fromAnyNode(node: ReflectSceneNode) {
-  const _tmp_img = MainImageRepository.instance
-    .get("fill-later-assets")
-    .addImage({
-      key: node.id,
-    });
+  const _tmp_img = MainImageRepository.instance.get(_asset_key).addImage({
+    key: node.id,
+  });
 
   const widget = new ImageWidget({
     key: keyFromNode(node),
@@ -56,6 +60,33 @@ function fromBooleanOperation(
   return fromAnyNode(booleanop);
 }
 
+/**
+ * bake a ellipse as an bitmap for irregular shape, (e.g. with startingAngle or innerRadius)
+ * @param node
+ * @returns
+ */
+function fromIrregularEllipse(node: ReflectEllipseNode): ImageWidget {
+  const _tmp_img = MainImageRepository.instance.get(_asset_key).addImage({
+    key: node.id,
+  });
+
+  const widget = new ImageWidget({
+    key: keyFromNode(node),
+    width: node.width,
+    height: node.height,
+    // we set to contin, since the ellipse' source size will be different from actual bound box size of the ellipse.
+    fit: BoxFit.contain,
+    // TODO: suppport alignment and centerSlice due to fit: contain.
+    // - alignment:
+    // - centerSlice:
+    semanticLabel: "image from ellipse",
+    src: _tmp_img.url,
+  });
+  widget.x = node.x;
+  widget.y = node.y;
+  return widget;
+}
+
 export const tokenizeBitmap = {
   fromStar: fromStar,
   fromPaint: fromPaint,
@@ -63,5 +94,6 @@ export const tokenizeBitmap = {
   fromGroup: fromGroup,
   fromFrame: fromFrame,
   fromBooleanOperation: fromBooleanOperation,
+  fromIrregularEllipse: fromIrregularEllipse,
   fromAnyNode: fromAnyNode,
 };

--- a/packages/designto-token/token-graphics/vector.ts
+++ b/packages/designto-token/token-graphics/vector.ts
@@ -24,11 +24,7 @@ function fromVector(vector: ReflectVectorNode) {
   if (!vector?.vectorPaths || vector.vectorPaths.length === 0) {
     // we are not sure when specifically this happens, but as reported, curvy lines does not contain a vector paths.
     // so we just return a image bake of it.
-    process.env.NODE_ENV === "development" &&
-      console.info(
-        `tried to get path data from vector, but none was provided. baking as a bitmap instead.`,
-        vector
-      );
+    // console.info(`tried to get path data from vector, but none was provided. baking as a bitmap instead.`, vector);
 
     return tokenizeBitmap.fromAnyNode(vector);
   }

--- a/packages/designto-token/token-graphics/vector.ts
+++ b/packages/designto-token/token-graphics/vector.ts
@@ -21,6 +21,8 @@ function fromPoligon(): VectorWidget {
 }
 
 function fromVector(vector: ReflectVectorNode) {
+  // TODO: support vector.fillGeomatery.
+
   if (!vector?.vectorPaths || vector.vectorPaths.length === 0) {
     // we are not sure when specifically this happens, but as reported, curvy lines does not contain a vector paths.
     // so we just return a image bake of it.

--- a/packages/designto-token/token-layout/index.ts
+++ b/packages/designto-token/token-layout/index.ts
@@ -250,7 +250,8 @@ function find_original(ogchildren: Array<nodes.ReflectSceneNode>, of: Widget) {
       // target the unwrapped child
       c.id === (_unwrappedChild && _unwrappedChild.key.id) ||
       // target the widget itself - some widgets are not wrapped, yet being converted to a container-like (e.g. maskier)
-      c.id === of.key.id
+      c.id === of.key.id ||
+      c.id === of.key.id.split(".")[0] // {id}.positioned or {id}.scroll-wrap TODO: this logic can cause problem later on.
   );
   if (!ogchild) {
     console.error(

--- a/packages/designto-token/token-layout/index.ts
+++ b/packages/designto-token/token-layout/index.ts
@@ -1,5 +1,6 @@
 import { nodes, ReflectSceneNodeType } from "@design-sdk/core";
 import { layoutAlignToReflectMainAxisSize } from "@design-sdk/figma-node-conversion";
+import type { Constraints } from "@design-sdk/figma-types";
 import * as core from "@reflect-ui/core";
 import {
   Axis,
@@ -278,7 +279,7 @@ function stackChild({
   container: nodes.ReflectSceneNode;
   wchild: core.Widget;
 }) {
-  const constraint = {
+  let constraint = {
     left: undefined,
     top: undefined,
     right: undefined,
@@ -290,15 +291,10 @@ function stackChild({
   const _unwrappedChild: IWHStyleWidget = unwrappedChild(
     child
   ) as IWHStyleWidget;
-  const wh = {
+  let wh = {
     width: _unwrappedChild.width,
     height: _unwrappedChild.height,
   };
-
-  const _l = ogchild.x;
-  const _r = container.width - (ogchild.x + ogchild.width);
-  const _t = ogchild.y;
-  const _b = container.height - (ogchild.y + ogchild.height);
 
   /**
    * "MIN": Left or Top
@@ -320,101 +316,25 @@ function stackChild({
     );
     // throw `${ogchild.toString()} has no constraints. this can happen when node under group item tokenization is incomplete. this is engine's error.`;
   } else {
-    switch (ogchild.constraints.horizontal) {
-      case "MIN":
-        constraint.left = _l;
-        break;
-      case "MAX":
-        constraint.right = _r;
-        break;
-      case "SCALE": /** scale fallbacks to stretch */
-      case "STRETCH":
-        constraint.left = _l;
-        constraint.right = _r;
-        wh.width = undefined; // no fixed width
-        break;
-      case "CENTER":
-        const half_w = ogchild.width / 2;
-        const centerdiff =
-          // center of og
-          half_w +
-          ogchild.x -
-          // center of frame
-          container.width / 2;
-        constraint.left = <Calculation>{
-          type: "calc",
-          operations: <Operation>{
-            type: "op",
-            left: {
-              type: "calc",
-              operations: <Operation>{
-                type: "op",
-                left: "50%",
-                op: "+",
-                right: centerdiff,
-              },
-            },
-            op: "-", // this part is different
-            right: half_w,
-          },
-        };
-        // --- we can also specify the right, but left is enough.
-        // constraint.right = <Calculation>{
-        //   type: "calc",
-        //   operations: {
-        //     left: {
-        //       type: "calc",
-        //       operations: { left: "50%", op: "+", right: centerdiff },
-        //     },
-        //     op: "+", // this part is different
-        //     right: half,
-        //   },
-        // };
-        break;
-    }
-    switch (ogchild.constraints.vertical) {
-      case "MIN":
-        constraint.top = _t;
-        break;
-      case "MAX":
-        constraint.bottom = _b;
-        break;
-      case "SCALE": /** scale fallbacks to stretch */
-      case "STRETCH":
-        constraint.top = _t;
-        constraint.bottom = _b;
-        wh.height = undefined;
-        break;
-      case "CENTER":
-        const half_height = ogchild.height / 2;
-        const container_snapshot_center = container.height / 2;
-        const child_snapshot_center = half_height + ogchild.y;
+    const _l = ogchild.x;
+    const _r = container.width - (ogchild.x + ogchild.width);
+    const _t = ogchild.y;
+    const _b = container.height - (ogchild.y + ogchild.height);
 
-        const centerdiff =
-          // center of og
-          child_snapshot_center -
-          // center of frame
-          container_snapshot_center;
+    const res = handlePositioning({
+      constraints: ogchild.constraints,
+      pos: { l: _l, t: _t, b: _b, r: _r, x: ogchild.x, y: ogchild.y },
+      width: ogchild.width,
+      height: ogchild.height,
+      containerWidth: container.width,
+      containerHeight: container.height,
+    });
 
-        constraint.top = <Calculation>{
-          type: "calc",
-          operations: <Operation>{
-            type: "op",
-            left: {
-              type: "calc",
-              operations: <Operation>{
-                type: "op",
-                left: "50%",
-                op: "+",
-                right: centerdiff,
-              },
-            },
-            op: "-", // this part is different
-            right: half_height,
-          },
-        };
-        break;
-    }
+    constraint = res.constraint;
+    wh = {
+      ...wh,
+      ...res.wh,
+    };
   }
 
   // console.log("positioning based on constraints", { wh, constraint, child });
@@ -428,6 +348,139 @@ function stackChild({
     ...wh,
     child: child,
   });
+}
+
+/**
+ * calculates the position & constraints based on the input.
+ * @param
+ * @returns
+ */
+function handlePositioning({
+  constraints,
+  pos,
+  width,
+  height,
+  containerWidth,
+  containerHeight,
+}: {
+  constraints: Constraints;
+  pos: { l: number; r: number; t: number; b: number; x: number; y: number };
+  width: number;
+  height: number;
+  containerWidth: number;
+  containerHeight: number;
+}): {
+  constraint;
+  wh: {
+    width?: number;
+    height?: number;
+  };
+} {
+  const constraint = {
+    left: undefined,
+    top: undefined,
+    right: undefined,
+    bottom: undefined,
+  };
+  const wh = { width, height };
+
+  switch (constraints.horizontal) {
+    case "MIN":
+      constraint.left = pos.l;
+      break;
+    case "MAX":
+      constraint.right = pos.r;
+      break;
+    case "SCALE": /** scale fallbacks to stretch */
+    case "STRETCH":
+      constraint.left = pos.l;
+      constraint.right = pos.r;
+      wh.width = undefined; // no fixed width
+      break;
+    case "CENTER":
+      const half_w = width / 2;
+      const centerdiff =
+        // center of og
+        half_w +
+        pos.x -
+        // center of frame
+        containerWidth / 2;
+      constraint.left = <Calculation>{
+        type: "calc",
+        operations: <Operation>{
+          type: "op",
+          left: {
+            type: "calc",
+            operations: <Operation>{
+              type: "op",
+              left: "50%",
+              op: "+",
+              right: centerdiff,
+            },
+          },
+          op: "-", // this part is different
+          right: half_w,
+        },
+      };
+      // --- we can also specify the right, but left is enough.
+      // constraint.right = <Calculation>{
+      //   type: "calc",
+      //   operations: {
+      //     left: {
+      //       type: "calc",
+      //       operations: { left: "50%", op: "+", right: centerdiff },
+      //     },
+      //     op: "+", // this part is different
+      //     right: half,
+      //   },
+      // };
+      break;
+  }
+  switch (constraints.vertical) {
+    case "MIN":
+      constraint.top = pos.t;
+      break;
+    case "MAX":
+      constraint.bottom = pos.b;
+      break;
+    case "SCALE": /** scale fallbacks to stretch */
+    case "STRETCH":
+      constraint.top = pos.t;
+      constraint.bottom = pos.b;
+      wh.height = undefined;
+      break;
+    case "CENTER":
+      const half_height = height / 2;
+      const container_snapshot_center = containerHeight / 2;
+      const child_snapshot_center = half_height + pos.y;
+
+      const centerdiff =
+        // center of og
+        child_snapshot_center -
+        // center of frame
+        container_snapshot_center;
+
+      constraint.top = <Calculation>{
+        type: "calc",
+        operations: <Operation>{
+          type: "op",
+          left: {
+            type: "calc",
+            operations: <Operation>{
+              type: "op",
+              left: "50%",
+              op: "+",
+              right: centerdiff,
+            },
+          },
+          op: "-", // this part is different
+          right: half_height,
+        },
+      };
+      break;
+  }
+
+  return { constraint, wh };
 }
 
 function fromGroup(

--- a/packages/designto-token/token-layout/index.ts
+++ b/packages/designto-token/token-layout/index.ts
@@ -8,7 +8,6 @@ import {
   Stack,
   Flex,
   Row,
-  Opacity,
   Positioned,
   Widget,
   VerticalDirection,
@@ -20,9 +19,6 @@ import {
   Calculation,
   Clip,
   Border,
-  ClipRRect,
-  Blurred,
-  Rotation,
   IWHStyleWidget,
   Operation,
 } from "@reflect-ui/core";
@@ -442,6 +438,7 @@ function handlePositioning({
       constraint.top = pos.t;
       break;
     case "MAX":
+      // TODO: add this custom logic - if fixed to bottom 0 , it should be fixed rather than absolute. (as a footer)
       constraint.bottom = pos.b;
       break;
     case "SCALE": /** scale fallbacks to stretch */

--- a/packages/designto-token/token-text/index.ts
+++ b/packages/designto-token/token-text/index.ts
@@ -47,6 +47,7 @@ export function fromText(node: nodes.ReflectTextNode): RenderedText {
       color: node.primaryColor,
       lineHeight: node.lineHeight,
       letterSpacing: node.letterSpacing,
+      textTransform: node.textCase,
       textShadow: node.shadows as TextShadowManifest[],
     }),
     ...wh,

--- a/packages/designto-token/token-widgets/button-widget.ts
+++ b/packages/designto-token/token-widgets/button-widget.ts
@@ -7,6 +7,7 @@ import { Colors, Container, EdgeInsets, WidgetKey } from "@reflect-ui/core";
 import assert from "assert";
 import { unwrappedChild } from "../wrappings";
 import { tokenizeLayout } from "../token-layout";
+import { WrappingContainer } from "../tokens";
 
 /**
  * Note - this universal button is used temporarily. the button tokens will be splited into more specific usecase following material button classification.
@@ -18,7 +19,7 @@ import { tokenizeLayout } from "../token-layout";
 function button(
   node: ReflectSceneNode,
   manifest: manifests.DetectedButtonManifest
-): core.ButtonStyleButton | core.Container<core.ButtonStyleButton> {
+): core.ButtonStyleButton | WrappingContainer<core.ButtonStyleButton> {
   assert(manifest.text, "text is required for button composing at this point");
 
   // TODO:
@@ -67,14 +68,14 @@ function button(
       )
     );
 
-    // @ts-ignore FIXME: no tsignore
-    return new Container({
+    return new WrappingContainer({
       ...container,
+      key: keyFromNode(node),
       child: button,
     });
   }
 
-  return new core.Container({
+  return new WrappingContainer({
     key: WidgetKey.copyWith(_key, { id: _key.id + ".sizedbox" }),
     width: sizing.width,
     height: sizing.height,

--- a/packages/designto-token/tokens/index.ts
+++ b/packages/designto-token/tokens/index.ts
@@ -1,1 +1,2 @@
 export * from "./stretched";
+export * from "./wrapping-container";

--- a/packages/designto-token/tokens/wrapping-container/index.ts
+++ b/packages/designto-token/tokens/wrapping-container/index.ts
@@ -1,0 +1,8 @@
+import { Container, Widget } from "@reflect-ui/core";
+
+/**
+ * Special token for wrapping a detected component with a container.
+ */
+export class WrappingContainer<
+  T extends Widget = Widget
+> extends Container<T> {}

--- a/packages/designto-token/wrappings/wrapping.ts
+++ b/packages/designto-token/wrappings/wrapping.ts
@@ -9,7 +9,7 @@ import {
   OverflowBox,
   SingleChildScrollView,
 } from "@reflect-ui/core";
-import { Stretched } from "../tokens";
+import { Stretched, WrappingContainer } from "../tokens";
 
 export type WrappingToken =
   // layout / positioning / sizing wrappers
@@ -25,7 +25,9 @@ export type WrappingToken =
   // effect wrappers
   | Blurred
   // clip wrappers
-  | ClipRRect;
+  | ClipRRect
+  // wrapping container
+  | WrappingContainer;
 
 /**
  * CAUTION - this is not related to `Wrap` Widget. this unwrapps a (nested) token that is wrapped with typeof `WrappingToken`
@@ -33,7 +35,7 @@ export type WrappingToken =
  * @returns
  */
 export function unwrappedChild<T extends Widget>(maybeWrapped: Widget): T {
-  if (
+  const isWrappingWidget =
     maybeWrapped instanceof SizedBox ||
     maybeWrapped instanceof Stretched ||
     maybeWrapped instanceof Positioned ||
@@ -42,8 +44,10 @@ export function unwrappedChild<T extends Widget>(maybeWrapped: Widget): T {
     maybeWrapped instanceof Rotation ||
     maybeWrapped instanceof Opacity ||
     maybeWrapped instanceof Blurred ||
-    maybeWrapped instanceof ClipRRect
-  ) {
+    maybeWrapped instanceof ClipRRect ||
+    maybeWrapped instanceof WrappingContainer;
+
+  if (isWrappingWidget) {
     return unwrappedChild(maybeWrapped.child);
   }
   return maybeWrapped as T;

--- a/packages/designto-web/tokens-to-web-widget/compose-wrapped-with-expanded.ts
+++ b/packages/designto-web/tokens-to-web-widget/compose-wrapped-with-expanded.ts
@@ -1,0 +1,13 @@
+import type { Composer } from ".";
+import { Expanded } from "@reflect-ui/core";
+
+export function compose_wrapped_with_expanded(
+  widget: Expanded,
+  child_composer: Composer
+) {
+  const child = child_composer(widget.child);
+  child.extendStyle({
+    flex: widget.flex,
+  });
+  return child;
+}

--- a/packages/designto-web/tokens-to-web-widget/compose-wrapped-with-rotation.ts
+++ b/packages/designto-web/tokens-to-web-widget/compose-wrapped-with-rotation.ts
@@ -7,8 +7,18 @@ export function compose_wrapped_with_rotation(
   child_composer: Composer
 ) {
   const child = child_composer(widget.child);
+
+  const r = widget.rotation;
+  // don't apply rotation if it's 0
+  if (Math.abs(r) === 360 || Math.abs(r) === 360) {
+    return child;
+  }
+
   child.extendStyle({
-    transform: css.rotation(widget.rotation),
+    // rotation data needs to be inverted
+    transform: css.rotation(-widget.rotation),
+    // this is where the figma's rotation data is originated from.
+    "transform-origin": "top left",
   });
   return child;
 }

--- a/packages/designto-web/tokens-to-web-widget/compose-wrapped-with-rotation.ts
+++ b/packages/designto-web/tokens-to-web-widget/compose-wrapped-with-rotation.ts
@@ -18,6 +18,7 @@ export function compose_wrapped_with_rotation(
     // rotation data needs to be inverted
     transform: css.rotation(-widget.rotation),
     // this is where the figma's rotation data is originated from.
+    // see docs/figma-rotation.md
     "transform-origin": "top left",
   });
   return child;

--- a/packages/designto-web/tokens-to-web-widget/compose-wrapped-with-stretched.ts
+++ b/packages/designto-web/tokens-to-web-widget/compose-wrapped-with-stretched.ts
@@ -19,6 +19,8 @@ export function compose_wrapped_with_clip_stretched(
   const child = child_composer(widget.child);
   child.extendStyle({
     "align-self": "stretch",
+    // TODO: this is required, for fixed width / height to work, but not sure this is the best place to be.
+    "flex-shrink": 0,
     [remove_size]: undefined,
   });
   return child;

--- a/packages/designto-web/tokens-to-web-widget/index.ts
+++ b/packages/designto-web/tokens-to-web-widget/index.ts
@@ -14,6 +14,7 @@ import { compose_wrapped_with_positioned } from "./compose-wrapped-with-position
 import { compose_wrapped_with_clip_stretched } from "./compose-wrapped-with-stretched";
 import { compose_wrapped_with_sized_box } from "./compose-wrapped-with-sized-box";
 import { compose_wrapped_with_overflow_box } from "./compose-wrapped-with-overflow-box";
+import { compose_wrapped_with_expanded } from "./compose-wrapped-with-expanded";
 import { compose_unwrapped_text_input } from "./compose-unwrapped-text-field";
 import { compose_unwrapped_button } from "./compose-unwrapped-button";
 import { compose_unwrapped_slider } from "./compose-unwrapped-slider";
@@ -144,6 +145,8 @@ function compose<T extends JsxWidget>(
     thisWebWidget = compose_wrapped_with_blurred(widget, handleChild);
   } else if (widget instanceof core.Rotation) {
     thisWebWidget = compose_wrapped_with_rotation(widget, handleChild);
+  } else if (widget instanceof core.Expanded) {
+    thisWebWidget = compose_wrapped_with_expanded(widget, handleChild);
   }
   // ----- region clip path ------
   else if (widget instanceof core.ClipRRect) {

--- a/packages/designto-web/tokens-to-web-widget/index.ts
+++ b/packages/designto-web/tokens-to-web-widget/index.ts
@@ -21,6 +21,7 @@ import { compose_instanciation } from "./compose-instanciation";
 import { IWHStyleWidget } from "@reflect-ui/core";
 import * as reusable from "@code-features/component/tokens";
 import assert from "assert";
+import { WrappingContainer } from "@designto/token/tokens";
 
 interface WebWidgetComposerConfig {
   /**
@@ -233,6 +234,23 @@ function compose<T extends JsxWidget>(
   } else if (widget instanceof core.Slider) {
     thisWebWidget = compose_unwrapped_slider(_key, widget);
   }
+  // wrapping container
+  else if (widget instanceof WrappingContainer) {
+    // #region
+    // mergable widgets for web
+    if (widget.child instanceof core.TextField) {
+      thisWebWidget = compose_unwrapped_text_input(_key, widget.child, widget);
+    } else if (widget.child instanceof core.ButtonStyleButton) {
+      thisWebWidget = compose_unwrapped_button(_key, widget.child, widget);
+    } else if (widget.child instanceof core.Slider) {
+      thisWebWidget = compose_unwrapped_slider(_key, widget.child, widget);
+    } else {
+      throw new Error(
+        `Unsupported widget type: ${widget.child.constructor.name}`
+      );
+    }
+    // #endregion
+  }
   // #endregion
 
   // execution order matters - some above widgets inherits from Container, this shall be handled at the last.
@@ -249,17 +267,6 @@ function compose<T extends JsxWidget>(
     container.y = widget.y;
     container.background = widget.background;
     thisWebWidget = container;
-
-    // #region
-    // mergable widgets for web
-    if (widget.child instanceof core.TextField) {
-      thisWebWidget = compose_unwrapped_text_input(_key, widget.child, widget);
-    } else if (widget.child instanceof core.ButtonStyleButton) {
-      thisWebWidget = compose_unwrapped_button(_key, widget.child, widget);
-    } else if (widget.child instanceof core.Slider) {
-      thisWebWidget = compose_unwrapped_slider(_key, widget.child, widget);
-    }
-    // #endregion
   }
 
   // -------------------------------------

--- a/packages/designto-web/tokens-to-web-widget/index.ts
+++ b/packages/designto-web/tokens-to-web-widget/index.ts
@@ -178,9 +178,11 @@ function compose<T extends JsxWidget>(
   } else if (widget instanceof core.ImageWidget) {
     thisWebWidget = new web.ImageElement({
       ...widget,
-      alt: config.img_no_alt ? "" : `image of ${_key.name}`,
-      src: widget.src,
       key: _key,
+      src: widget.src,
+      alt: config.img_no_alt
+        ? ""
+        : widget.semanticLabel ?? `image of ${_key.name}`,
     });
   } else if (widget instanceof core.IconWidget) {
     // TODO: not ready - svg & named icon not supported

--- a/packages/support-flags/--artwork/index.ts
+++ b/packages/support-flags/--artwork/index.ts
@@ -1,5 +1,13 @@
 export const flag_key__artwork = "artwork";
 
+const flag_key__as_artwork = "as-artwork";
+
+export const flag_key_alias__artwork = [
+  //
+  flag_key__artwork,
+  flag_key__as_artwork,
+] as const;
+
 export interface ArtworkFlag {
   flag: typeof flag_key__artwork;
   value?: boolean;

--- a/packages/support-flags/--autofocus/index.ts
+++ b/packages/support-flags/--autofocus/index.ts
@@ -1,0 +1,13 @@
+export const flag_key__autofocus = "autofocus";
+// alias
+const flag_key__auto_focus = "auto-focus";
+
+export const flag_key_alias__autofocus = [
+  flag_key__autofocus,
+  flag_key__auto_focus,
+];
+
+export interface AutofocusFlag {
+  flag: typeof flag_key__autofocus;
+  value?: boolean;
+}

--- a/packages/support-flags/keys.ts
+++ b/packages/support-flags/keys.ts
@@ -1,3 +1,5 @@
+import { flag_key_alias__autofocus, flag_key__autofocus } from "./--autofocus";
+
 import { flag_key_alias__as_h1, flag_key__as_h1 } from "./--as-h1";
 import { flag_key_alias__as_h2, flag_key__as_h2 } from "./--as-h2";
 import { flag_key_alias__as_h3, flag_key__as_h3 } from "./--as-h3";
@@ -25,6 +27,12 @@ import { flag_key_alias__fix_width, flag_key__fix_width } from "./--fix-width";
 import { flag_key_alias__fix_height, flag_key__fix_height } from "./--fix-height";
 
 import { flag_key_alias__declare, flag_key__declare } from "./--declare";
+
+//
+export {
+  //
+  flag_key__autofocus,
+};
 
 export {
   flag_key__as_h1,
@@ -57,6 +65,7 @@ export { flag_key__fix_width, flag_key__fix_height };
 export { flag_key__declare };
 
 export const alias = {
+  autofocus: flag_key_alias__autofocus,
   as_h1: flag_key_alias__as_h1,
   as_h2: flag_key_alias__as_h2,
   as_h3: flag_key_alias__as_h3,

--- a/packages/support-flags/types.ts
+++ b/packages/support-flags/types.ts
@@ -1,3 +1,4 @@
+import type { AutofocusFlag } from "./--autofocus";
 import type { ArtworkFlag } from "./--artwork";
 import type { AsHeading1Flag } from "./--as-h1";
 import type { AsHeading2Flag } from "./--as-h2";
@@ -21,14 +22,13 @@ import type { FixHeightFlag } from "./--fix-height";
 import type { DeclareSpecificationFlag } from "./--declare";
 
 export type Flag =
-  //
+  | AutofocusFlag
   | ArtworkFlag
   | TextElementPreferenceFlag
-  //
   | WHDeclarationFlag
   | FixWHFlag
-  //
-  | DeclareSpecificationFlag;
+  | DeclareSpecificationFlag
+  | ComponentCastingFlag;
 
 export interface SimpleBooleanValueFlag {
   flag: string;
@@ -78,6 +78,16 @@ export type HeadingFlag =
   | AsHeading4Flag
   | AsHeading5Flag
   | AsHeading6Flag;
+
+/**
+ * Type alias for a flag taht can be used to specify the element casting
+ */
+export type ComponentCastingFlag = AsButtonFlag | AsInputFlag | AsSliderFlag;
+
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+
+export type { AutofocusFlag };
 
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- [x] TextField widget support for web - https://github.com/gridaco/designto-code/pull/127
- [x] Slider widget support for web - https://github.com/gridaco/designto-code/pull/130
- [x] Button widget support for web - https://github.com/gridaco/designto-code/pull/108



[![Grida _ D2C March#3 release demo-high](https://user-images.githubusercontent.com/16307013/160309652-e3dce068-0f34-42ed-9482-b126662ad276.gif)](https://vimeo.com/692912807)

> demo video: https://vimeo.com/692912807


Fixes
- fix: text-transform being specified even set to `'none'`
- shorthand named color such as white and black on css build
- fix flex-shrink not applied on fixed item - #32 , https://github.com/gridaco/designto-code/issues/99


On next release
- [ ] Link widget support for web
- [ ] Better Scrolling area specification support for web
- [ ] CSS Optimization, style sharing